### PR TITLE
Add Hypixel API key config for BedWars fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Levelhead is a Minecraft Mod created for the Hypixel Network `mc.hypixel.net` to
 
 `/levelhead reauth` - Refreshes the current purchase data for your player
 
+`/levelhead apikey <key>` - Stores your Hypixel API key for BedWars stat lookups.
+
+`/levelhead clearapikey` - Removes the stored Hypixel API key from `config/bedwars-level-head.cfg`.
+
 ### Gui 
 
 `MasterToggle` - Toggle mod on and off

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -3,6 +3,7 @@ package club.sk1er.mods.levelhead
 import club.sk1er.mods.levelhead.auth.MojangAuth
 import club.sk1er.mods.levelhead.commands.LevelheadCommand
 import club.sk1er.mods.levelhead.config.DisplayConfig
+import club.sk1er.mods.levelhead.config.LevelheadConfig
 import club.sk1er.mods.levelhead.core.DisplayManager
 import club.sk1er.mods.levelhead.core.RateLimiter
 import club.sk1er.mods.levelhead.core.dashUUID
@@ -88,6 +89,9 @@ object Levelhead {
 
     @Mod.EventHandler
     fun preInit(event: FMLPreInitializationEvent) {
+        val configDirectory = event.modConfigurationDirectory ?: File(UMinecraft.getMinecraft().mcDataDir, "config")
+        val configFile = File(configDirectory, "bedwars-level-head.cfg")
+        LevelheadConfig.initialize(configFile)
         scope.launch {
             refreshTypes()
         }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/bedwars/BedwarsFetcher.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/bedwars/BedwarsFetcher.kt
@@ -1,0 +1,91 @@
+package club.sk1er.mods.levelhead.bedwars
+
+import club.sk1er.mods.levelhead.Levelhead
+import club.sk1er.mods.levelhead.config.LevelheadConfig
+import com.google.gson.JsonObject
+import gg.essential.api.EssentialAPI
+import gg.essential.api.utils.Multithreading
+import gg.essential.universal.ChatColor
+import okhttp3.HttpUrl
+import okhttp3.Request
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+object BedwarsFetcher {
+    private const val HYPIXEL_PLAYER_ENDPOINT = "https://api.hypixel.net/player"
+
+    private val missingKeyWarned = AtomicBoolean(false)
+    private val invalidKeyWarned = AtomicBoolean(false)
+
+    fun fetchPlayer(uuid: UUID): JsonObject? {
+        val key = LevelheadConfig.apiKey
+        if (key.isBlank()) {
+            notifyMissingKey()
+            return null
+        }
+
+        val url = HttpUrl.parse(HYPIXEL_PLAYER_ENDPOINT)?.newBuilder()
+            ?.addQueryParameter("key", key)
+            ?.addQueryParameter("uuid", uuid.toString().replace("-", ""))
+            ?.build()
+
+        if (url == null) {
+            Levelhead.logger.error("Failed to build Hypixel BedWars endpoint URL")
+            return null
+        }
+
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", "Levelhead/${Levelhead.VERSION}")
+            .get()
+            .build()
+
+        return try {
+            Levelhead.okHttpClient.newCall(request).execute().use { response ->
+                val body = response.body()?.string() ?: return null
+                val json = Levelhead.jsonParser.parse(body).asJsonObject
+                if (!json.get("success")?.asBoolean ?: false) {
+                    val cause = json.get("cause")?.asString ?: "Unknown"
+                    notifyInvalidKey(cause)
+                    return null
+                }
+                invalidKeyWarned.set(false)
+                json
+            }
+        } catch (ex: Exception) {
+            Levelhead.logger.error("Failed to fetch Hypixel BedWars data", ex)
+            null
+        }
+    }
+
+    fun resetWarnings() {
+        missingKeyWarned.set(false)
+        invalidKeyWarned.set(false)
+    }
+
+    private fun notifyMissingKey() {
+        if (missingKeyWarned.compareAndSet(false, true)) {
+            sendMessage(
+                "${ChatColor.YELLOW}Set your Hypixel API key with ${ChatColor.GOLD}/levelhead apikey <key>${ChatColor.YELLOW} to enable BedWars stats."
+            )
+        }
+    }
+
+    private fun notifyInvalidKey(cause: String) {
+        if (cause.contains("api key", ignoreCase = true)) {
+            if (invalidKeyWarned.compareAndSet(false, true)) {
+                sendMessage(
+                    "${ChatColor.RED}Hypixel rejected your API key (${cause.trim()}). ${ChatColor.YELLOW}Update it with ${ChatColor.GOLD}/levelhead apikey <key>${ChatColor.YELLOW}."
+                )
+            }
+        } else {
+            Levelhead.logger.warn("Hypixel API returned error: {}", cause)
+        }
+    }
+
+    private fun sendMessage(message: String) {
+        Multithreading.runOnMainThread {
+            EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", message)
+        }
+    }
+}

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -3,6 +3,7 @@ package club.sk1er.mods.levelhead.commands
 import club.sk1er.mods.levelhead.Levelhead
 import club.sk1er.mods.levelhead.Levelhead.displayManager
 import club.sk1er.mods.levelhead.Levelhead.types
+import club.sk1er.mods.levelhead.config.LevelheadConfig
 import club.sk1er.mods.levelhead.gui.LevelheadGUI
 import gg.essential.api.EssentialAPI
 import gg.essential.api.commands.Command
@@ -14,15 +15,22 @@ import kotlinx.coroutines.launch
 
 class LevelheadCommand : Command("levelhead") {
 
+    companion object {
+        private val API_KEY_PATTERN = Regex("^[a-f0-9]{32}$", RegexOption.IGNORE_CASE)
+        private var remindedAboutApiKey = false
+    }
+
     @DefaultHandler
     fun handle() {
         try {
             EssentialAPI.getGuiUtil().openScreen(LevelheadGUI())
         } catch (_: Exception) {
             EssentialAPI.getMinecraftUtil().sendMessage(
-            "${ChatColor.AQUA}[Levelhead]", message = "${ChatColor.RED} Failed to open menu. Server might be down. Try restarting your game."
+                "${ChatColor.AQUA}[Levelhead]", message = "${ChatColor.RED} Failed to open menu. Server might be down. Try restarting your game."
             )
+            return
         }
+        remindToSetApiKey()
     }
 
     @SubCommand(value = "limit")
@@ -64,5 +72,48 @@ class LevelheadCommand : Command("levelhead") {
         Levelhead.rateLimiter.resetState()
         displayManager.clearCache()
         EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", "${ChatColor.GREEN} Cleared Cache")
+    }
+
+    @SubCommand(value = "apikey", aliases = ["setapikey"])
+    fun handleApiKey(key: String) {
+        if (key.equals("clear", ignoreCase = true)) {
+            LevelheadConfig.clearApiKey()
+            EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", "${ChatColor.GREEN} Cleared stored Hypixel API key.")
+            return
+        }
+
+        val sanitized = key.trim()
+        val normalized = sanitized.replace("-", "")
+        if (!API_KEY_PATTERN.matches(normalized)) {
+            EssentialAPI.getMinecraftUtil().sendMessage(
+                "${ChatColor.AQUA}[Levelhead]",
+                "${ChatColor.RED}Invalid Hypixel API key. Keys should be 32 hexadecimal characters."
+            )
+            return
+        }
+
+        LevelheadConfig.setApiKey(sanitized)
+        EssentialAPI.getMinecraftUtil().sendMessage(
+            "${ChatColor.AQUA}[Levelhead]",
+            "${ChatColor.GREEN}Saved Hypixel API key for BedWars stat fetching."
+        )
+        remindedAboutApiKey = true
+    }
+
+    @SubCommand(value = "clearapikey")
+    fun handleClearApiKey() {
+        LevelheadConfig.clearApiKey()
+        EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", "${ChatColor.GREEN} Cleared stored Hypixel API key.")
+        remindedAboutApiKey = false
+    }
+
+    private fun remindToSetApiKey() {
+        if (LevelheadConfig.apiKey.isBlank() && !remindedAboutApiKey) {
+            remindedAboutApiKey = true
+            EssentialAPI.getMinecraftUtil().sendMessage(
+                "${ChatColor.AQUA}[Levelhead]",
+                "${ChatColor.YELLOW}Set your Hypixel API key with ${ChatColor.GOLD}/levelhead apikey <key>${ChatColor.YELLOW} to enable BedWars stats."
+            )
+        }
     }
 }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -1,0 +1,49 @@
+package club.sk1er.mods.levelhead.config
+
+import club.sk1er.mods.levelhead.bedwars.BedwarsFetcher
+import net.minecraftforge.common.config.Configuration
+import java.io.File
+
+object LevelheadConfig {
+    private const val CATEGORY_GENERAL = "general"
+    private const val PROPERTY_API_KEY = "hypixelApiKey"
+    private const val API_KEY_COMMENT = "Hypixel API key used for BedWars integrations"
+
+    private lateinit var configuration: Configuration
+
+    var apiKey: String = ""
+        private set
+
+    fun initialize(configFile: File) {
+        configFile.parentFile?.takeIf { !it.exists() }?.mkdirs()
+        configuration = Configuration(configFile)
+        load()
+    }
+
+    private fun load() {
+        configuration.load()
+        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
+        apiKey = property.string.trim()
+        if (configuration.hasChanged()) {
+            configuration.save()
+        }
+    }
+
+    fun setApiKey(newKey: String) {
+        ensureInitialized()
+        val sanitized = newKey.trim()
+        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
+        property.string = sanitized
+        apiKey = sanitized
+        configuration.save()
+        BedwarsFetcher.resetWarnings()
+    }
+
+    fun clearApiKey() {
+        setApiKey("")
+    }
+
+    private fun ensureInitialized() {
+        check(::configuration.isInitialized) { "LevelheadConfig has not been initialized yet" }
+    }
+}


### PR DESCRIPTION
## Summary
- load a Forge configuration on pre-init to persist the Hypixel API key
- add commands and reminders for saving or clearing the stored key
- implement a BedWars fetcher that reads the saved key and surfaces validation failures
- document the new commands for managing the API key

## Testing
- ./gradlew check *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68ece4145ad0832d85c210945cae7696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added in-game commands to manage your Hypixel API key: “/levelhead apikey <key>” to set and “/levelhead clearapikey” to remove.
  - API key is now saved to your config and loaded automatically at startup.
  - Improved feedback: one-time reminders if no key is set and clear messages when an invalid key is detected.
  - Enhanced Bed Wars data fetching using your stored API key.

- Documentation
  - README updated with instructions for setting and clearing the API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->