### PR TITLE
Adjust Levelhead rate limiter for new throttle window

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -72,7 +72,7 @@ object Levelhead {
     val displayManager: DisplayManager = DisplayManager(File(File(UMinecraft.getMinecraft().mcDataDir, "config"), "levelhead.json"))
     val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val mutex: Mutex = Mutex()
-    val rateLimiter: RateLimiter = RateLimiter(100, Duration.ofSeconds(1))
+    val rateLimiter: RateLimiter = RateLimiter(150, Duration.ofMinutes(5))
     private val format: DecimalFormat = DecimalFormat("#,###")
     val DarkChromaColor: Int
         get() = Color.HSBtoRGB(System.currentTimeMillis() % 1000 / 1000f, 0.8f, 0.2f)

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/RateLimiter.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/RateLimiter.kt
@@ -46,6 +46,12 @@ class RateLimiter constructor(
         if (isNextInterval) resetState()
 
         if (isAtCapacity) {
+            val now = clock.instant()
+            val waitDuration = Duration.between(now, nextInterval)
+            val safeWait = if (waitDuration.isNegative) Duration.ZERO else waitDuration
+            Levelhead.logger.info(
+                "Reached Levelhead API throttle (150 requests per 5 minutes). Waiting ${safeWait.toMinutes()} minutes (${safeWait.seconds} seconds) before retrying."
+            )
             delayUntilNextInterval()
             resetState()
         }


### PR DESCRIPTION
## Summary
- update the Levelhead rate limiter to allow 150 requests per five-minute window in line with the new API throttle
- log a clear diagnostic message when the limiter reaches the throttle so users understand the five-minute wait

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ece4126560832db4db417a7a3b2b36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance
  - Increased request allowance and extended the rate-limiting window to reduce interruptions and improve responsiveness during bursts of activity.
  - Users should experience smoother, more consistent behavior under heavier usage.

- Logging
  - Added informative messages when throttling occurs, showing the estimated wait time before retry.
  - Provides clearer feedback for diagnosing slowdowns related to rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->