### PR TITLE
Improve BedWars integration robustness

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/bedwars/BedwarsFetcher.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/bedwars/BedwarsFetcher.kt
@@ -4,9 +4,9 @@ import club.sk1er.mods.levelhead.Levelhead
 import club.sk1er.mods.levelhead.config.LevelheadConfig
 import com.google.gson.JsonObject
 import gg.essential.api.EssentialAPI
-import gg.essential.api.utils.Multithreading
 import gg.essential.universal.ChatColor
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import gg.essential.universal.UMinecraft
+import okhttp3.HttpUrl
 import okhttp3.Request
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -24,7 +24,7 @@ object BedwarsFetcher {
             return null
         }
 
-        val url = HYPIXEL_PLAYER_ENDPOINT.toHttpUrlOrNull()?.newBuilder()
+        val url = HttpUrl.parse(HYPIXEL_PLAYER_ENDPOINT)?.newBuilder()
             ?.addQueryParameter("key", key)
             ?.addQueryParameter("uuid", uuid.toString().replace("-", ""))
             ?.build()
@@ -44,7 +44,7 @@ object BedwarsFetcher {
             Levelhead.okHttpClient.newCall(request).execute().use { response ->
                 val body = response.body()?.string() ?: return null
                 val json = Levelhead.jsonParser.parse(body).asJsonObject
-                if (!json.get("success")?.asBoolean ?: false) {
+                if (json.get("success")?.asBoolean != true) {
                     val cause = json.get("cause")?.asString ?: "Unknown"
                     notifyInvalidKey(cause)
                     return null
@@ -88,7 +88,7 @@ object BedwarsFetcher {
     }
 
     private fun sendMessage(message: String) {
-        Multithreading.runOnMainThread {
+        UMinecraft.getMinecraft().addScheduledTask {
             EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", message)
         }
     }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -10,8 +10,9 @@ import gg.essential.api.commands.Command
 import gg.essential.api.commands.DefaultHandler
 import gg.essential.api.commands.SubCommand
 import gg.essential.universal.ChatColor
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.cancelChildren
+import java.util.Locale
 
 class LevelheadCommand : Command("levelhead") {
 
@@ -107,8 +108,30 @@ class LevelheadCommand : Command("levelhead") {
         remindedAboutApiKey = false
     }
 
+    @SubCommand(value = "bedwars")
+    fun handleBedwarsToggle(state: String) {
+        val normalized = state.trim().lowercase(Locale.ROOT)
+        val enabled = when (normalized) {
+            "on", "enable", "enabled", "true" -> true
+            "off", "disable", "disabled", "false" -> false
+            else -> {
+                EssentialAPI.getMinecraftUtil().sendMessage(
+                    "${ChatColor.AQUA}[Levelhead]",
+                    "${ChatColor.RED}Usage: /levelhead bedwars <on|off>"
+                )
+                return
+            }
+        }
+
+        LevelheadConfig.setBedwarsIntegrationEnabled(enabled)
+        EssentialAPI.getMinecraftUtil().sendMessage(
+            "${ChatColor.AQUA}[Levelhead]",
+            if (enabled) "${ChatColor.GREEN}Enabled BedWars star integration." else "${ChatColor.YELLOW}Disabled BedWars star integration."
+        )
+    }
+
     private fun remindToSetApiKey() {
-        if (LevelheadConfig.apiKey.isBlank() && !remindedAboutApiKey) {
+        if (LevelheadConfig.bedwarsIntegrationEnabled && LevelheadConfig.apiKey.isBlank() && !remindedAboutApiKey) {
             remindedAboutApiKey = true
             EssentialAPI.getMinecraftUtil().sendMessage(
                 "${ChatColor.AQUA}[Levelhead]",

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -8,10 +8,15 @@ object LevelheadConfig {
     private const val CATEGORY_GENERAL = "general"
     private const val PROPERTY_API_KEY = "hypixelApiKey"
     private const val API_KEY_COMMENT = "Hypixel API key used for BedWars integrations"
+    private const val PROPERTY_BEDWARS_ENABLED = "bedwarsIntegrationEnabled"
+    private const val BEDWARS_ENABLED_COMMENT = "Enable fetching and rendering BedWars stars"
 
     private lateinit var configuration: Configuration
 
     var apiKey: String = ""
+        private set
+
+    var bedwarsIntegrationEnabled: Boolean = true
         private set
 
     fun initialize(configFile: File) {
@@ -22,8 +27,16 @@ object LevelheadConfig {
 
     private fun load() {
         configuration.load()
-        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
-        apiKey = property.string.trim()
+        val apiKeyProperty = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
+        apiKey = apiKeyProperty.string.trim()
+
+        val enabledProperty = configuration.get(
+            CATEGORY_GENERAL,
+            PROPERTY_BEDWARS_ENABLED,
+            true,
+            BEDWARS_ENABLED_COMMENT
+        )
+        bedwarsIntegrationEnabled = enabledProperty.boolean
         if (configuration.hasChanged()) {
             configuration.save()
         }
@@ -33,7 +46,7 @@ object LevelheadConfig {
         ensureInitialized()
         val sanitized = newKey.trim()
         val property = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
-        property.string = sanitized
+        property.set(sanitized)
         apiKey = sanitized
         configuration.save()
         BedwarsFetcher.resetWarnings()
@@ -41,6 +54,19 @@ object LevelheadConfig {
 
     fun clearApiKey() {
         setApiKey("")
+    }
+
+    fun setBedwarsIntegrationEnabled(enabled: Boolean) {
+        ensureInitialized()
+        val property = configuration.get(
+            CATEGORY_GENERAL,
+            PROPERTY_BEDWARS_ENABLED,
+            true,
+            BEDWARS_ENABLED_COMMENT
+        )
+        property.set(enabled)
+        bedwarsIntegrationEnabled = enabled
+        configuration.save()
     }
 
     private fun ensureInitialized() {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
@@ -26,11 +26,21 @@ object BedwarsStar {
 
     fun extractExperience(player: JsonObject?): Long? {
         player ?: return null
-        val stats = player.getAsJsonObject("stats") ?: return null
-        val bedwars = stats.getAsJsonObject("Bedwars") ?: return null
+
+        val statsElement = player.get("stats") ?: return null
+        if (!statsElement.isJsonObject) return null
+        val stats = statsElement.asJsonObject
+
+        val bedwarsElement = stats.get("Bedwars") ?: return null
+        if (!bedwarsElement.isJsonObject) return null
+        val bedwars = bedwarsElement.asJsonObject
+
         val experienceEntry = bedwars.entrySet()
-            .firstOrNull { (key, _) -> key.equals("Experience", true) || key.equals("bedwars_experience", true) }
+            .firstOrNull { (key, _) ->
+                key.equals("Experience", ignoreCase = true) || key.equals("bedwars_experience", ignoreCase = true)
+            }
             ?: return null
+
         return kotlin.runCatching { experienceEntry.value.asLong }.getOrNull()
     }
 
@@ -60,10 +70,12 @@ object BedwarsStar {
 
     fun styleForStar(star: Int): PrestigeStyle {
         if (star >= 1000) {
-            return PrestigeStyle(ChatColor.WHITE.color!!, true)
+            val color = ChatColor.WHITE.color ?: Color.WHITE
+            return PrestigeStyle(color, true)
         }
         val prestige = (star / 100).coerceAtLeast(0)
-        val chatColor = prestigeColors.getOrNull(prestige)?.color ?: ChatColor.GRAY.color!!
+        val fallback = ChatColor.GRAY.color ?: Color.GRAY
+        val chatColor = prestigeColors.getOrNull(prestige)?.color ?: fallback
         return PrestigeStyle(chatColor, false)
     }
 }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/render/AboveHeadRender.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/render/AboveHeadRender.kt
@@ -35,6 +35,8 @@ object AboveHeadRender {
         if (event.entity !is EntityPlayer) return
         val player = event.entity as EntityPlayer
 
+        val localPlayer = UMinecraft.getPlayer()
+
         displayManager.aboveHead.forEachIndexed { index, display ->
             if (index > Levelhead.LevelheadPurchaseStates.aboveHead
                 || !display.config.enabled
@@ -43,7 +45,9 @@ object AboveHeadRender {
             if (display.loadOrRender(player) && tag != null) {
                 // increase offset if there's something in the above name slot for scoreboards
                 var offset = 0.3
-                if (player.worldScoreboard.getObjectiveInDisplaySlot(2) != null && player.getDistanceSqToEntity(UMinecraft.getPlayer()!!) < 100) {
+                val hasScoreboardObjective = player.worldScoreboard?.getObjectiveInDisplaySlot(2) != null
+                val isCloseToLocalPlayer = localPlayer?.let { player.getDistanceSqToEntity(it) < 100 } ?: false
+                if (hasScoreboardObjective && isCloseToLocalPlayer) {
                     offset *= 2
                 }
                 if (player.isSelf) offset = 0.0


### PR DESCRIPTION
## Summary
- fix BedWars experience extraction to use safe Gson member access and avoid null color crashes when styling stars
- make BedWars scoreboard detection more permissive and gate requests behind a configurable toggle
- expose a Forge config/command toggle for BedWars integration and harden nameplate rendering against null players
- restore build compatibility by using OkHttp 3 APIs, scheduling UI updates on the Minecraft thread, guaranteeing a fallback LevelheadTag, and using reflection-safe scoreboard title parsing

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_68ee675078fc832d959b79aeb1753550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a toggle to enable/disable BedWars integration (via command and config).
  * API key reminder now shows only when BedWars integration is enabled.

* Bug Fixes
  * Safer API response handling to prevent crashes on empty responses.
  * More resilient BedWars stats parsing and prestige/star color handling.
  * Null-safe checks in above-head rendering to avoid errors near the local player.
  * Improved success checks and URL construction for BedWars fetches.

* Refactor
  * More robust BedWars mode detection and consistent tag rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->