### PR TITLE
Add manual workflow to build 1.8.9 jar

### DIFF
--- a/.github/workflows/build-1-8-9.yml
+++ b/.github/workflows/build-1-8-9.yml
@@ -1,0 +1,33 @@
+name: Build 1.8.9 Jar
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build 1.8.9 jar
+        run: ./gradlew :1.8.9:build
+
+      - name: Upload 1.8.9 jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: levelhead-1.8.9-jar
+          path: versions/1.8.9/build/libs/*.jar
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a workflow_dispatch-triggered GitHub Actions pipeline dedicated to the 1.8.9 build
- upload the generated 1.8.9 jar as an artifact for manual downloads

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68ee6f3cb19c832d95903579be1137ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to build and publish the 1.8.9 JAR on demand. This streamlines release preparation, ensures consistent build outputs, and makes artifacts readily available for download and testing. No changes to app behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->