### PR TITLE
Enhance BedWars detection and prestige styling

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -112,6 +112,7 @@ object Levelhead {
     fun postInit(ignored: FMLPostInitializationEvent) {
         MinecraftForge.EVENT_BUS.register(AboveHeadRender)
         MinecraftForge.EVENT_BUS.register(ChatRender)
+        MinecraftForge.EVENT_BUS.register(BedwarsModeDetector)
         MinecraftForge.EVENT_BUS.register(this)
         EssentialAPI.getCommandRegistry().registerCommand(LevelheadCommand())
     }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
@@ -9,17 +9,58 @@ object BedwarsStar {
     private const val EXPERIENCE_PER_LEVEL = 5000L
     private const val EXPERIENCE_PER_PRESTIGE = 487_000L
 
-    private val prestigeColors = listOf(
-        ChatColor.GRAY,
-        ChatColor.WHITE,
-        ChatColor.GOLD,
-        ChatColor.AQUA,
-        ChatColor.GREEN,
-        ChatColor.DARK_RED,
-        ChatColor.LIGHT_PURPLE,
-        ChatColor.DARK_GRAY,
-        ChatColor.DARK_AQUA,
-        ChatColor.BLACK
+    private val prestigeStyles = listOf(
+        PrestigeStyle(Color.decode("#AAAAAA"), false), // Stone
+        PrestigeStyle(Color.decode("#FFFFFF"), false), // Iron
+        PrestigeStyle(Color.decode("#FFAA00"), false), // Gold
+        PrestigeStyle(Color.decode("#55FFFF"), false), // Diamond
+        PrestigeStyle(Color.decode("#55FF55"), false), // Emerald
+        PrestigeStyle(Color.decode("#0000AA"), false), // Sapphire
+        PrestigeStyle(Color.decode("#FF5555"), false), // Ruby
+        PrestigeStyle(Color.decode("#FF55FF"), false), // Crystal
+        PrestigeStyle(Color.decode("#00AAAA"), false), // Opal
+        PrestigeStyle(Color.decode("#AA00AA"), false), // Amethyst
+        PrestigeStyle(Color.WHITE, true), // Rainbow
+        PrestigeStyle(Color.decode("#FFFFFF"), false), // Iron Prime
+        PrestigeStyle(Color.decode("#FFAA00"), false), // Gold Prime
+        PrestigeStyle(Color.decode("#55FFFF"), false), // Diamond Prime
+        PrestigeStyle(Color.decode("#55FF55"), false), // Emerald Prime
+        PrestigeStyle(Color.decode("#0000AA"), false), // Sapphire Prime
+        PrestigeStyle(Color.decode("#FF5555"), false), // Ruby Prime
+        PrestigeStyle(Color.decode("#FF55FF"), false), // Crystal Prime
+        PrestigeStyle(Color.decode("#00AAAA"), false), // Opal Prime
+        PrestigeStyle(Color.decode("#AA00AA"), false), // Amethyst Prime
+        PrestigeStyle(Color.decode("#AAAAAA"), false), // Mirror
+        PrestigeStyle(Color.decode("#FFAA00"), false), // Light
+        PrestigeStyle(Color.decode("#FFFF55"), false), // Dawn
+        PrestigeStyle(Color.decode("#AA00AA"), false), // Dusk
+        PrestigeStyle(Color.decode("#FFFFFF"), false), // Air
+        PrestigeStyle(Color.decode("#55FF55"), false), // Wind
+        PrestigeStyle(Color.decode("#FF55FF"), false), // Nebula
+        PrestigeStyle(Color.decode("#FFFF55"), false), // Thunder
+        PrestigeStyle(Color.decode("#FFAA00"), false), // Earth
+        PrestigeStyle(Color.decode("#55FFFF"), false), // Water
+        PrestigeStyle(Color.decode("#FF5555"), false), // Fire
+        PrestigeStyle(Color.decode("#FFFF55"), false), // Sunshine
+        PrestigeStyle(Color.decode("#FF5555"), false), // Eclipse
+        PrestigeStyle(Color.decode("#AA0000"), false), // Gamma
+        PrestigeStyle(Color.decode("#FF55FF"), false), // Majestic
+        PrestigeStyle(Color.decode("#55FF55"), false), // Andesine
+        PrestigeStyle(Color.decode("#00AAAA"), false), // Marine
+        PrestigeStyle(Color.decode("#55FFFF"), false), // Element
+        PrestigeStyle(Color.decode("#AA00AA"), false), // Galaxy
+        PrestigeStyle(Color.decode("#55FF55"), false), // Atomic
+        PrestigeStyle(Color.decode("#FFAA00"), false), // Sunset
+        PrestigeStyle(Color.decode("#FFFFFF"), false), // Time
+        PrestigeStyle(Color.decode("#AAAAAA"), false), // Winter
+        PrestigeStyle(Color.decode("#00AAAA"), false), // Obsidian
+        PrestigeStyle(Color.decode("#FF55FF"), false), // Spring
+        PrestigeStyle(Color.decode("#55FFFF"), false), // Ice
+        PrestigeStyle(Color.decode("#FFFFFF"), false), // Summer
+        PrestigeStyle(Color.decode("#AA00AA"), false), // Spinel
+        PrestigeStyle(Color.decode("#55FF55"), false), // Autumn
+        PrestigeStyle(Color.decode("#00AA00"), false), // Mystic
+        PrestigeStyle(Color.decode("#AA0000"), false) // Eternal
     )
 
     data class PrestigeStyle(val color: Color, val chroma: Boolean)
@@ -69,13 +110,9 @@ object BedwarsStar {
     }
 
     fun styleForStar(star: Int): PrestigeStyle {
-        if (star >= 1000) {
-            val color = ChatColor.WHITE.color ?: Color.WHITE
-            return PrestigeStyle(color, true)
-        }
-        val prestige = (star / 100).coerceAtLeast(0)
-        val fallback = ChatColor.GRAY.color ?: Color.GRAY
-        val chatColor = prestigeColors.getOrNull(prestige)?.color ?: fallback
-        return PrestigeStyle(chatColor, false)
+        val prestigeIndex = (star / 100).coerceAtLeast(0)
+        val fallback = PrestigeStyle(ChatColor.GRAY.color ?: Color.GRAY, false)
+        val prestigeStyle = prestigeStyles.getOrNull(prestigeIndex) ?: prestigeStyles.lastOrNull() ?: fallback
+        return prestigeStyle.copy()
     }
 }


### PR DESCRIPTION
## Summary
- update BedWars prestige colors to the expanded set including chroma rainbow
- register BedwarsModeDetector on the event bus and add chat keyword detection to improve context tracking
- fall back to chat-driven context when scoreboard data is unavailable

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_b_68ee76a03eb4832da8b5d585591bd06f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds chat-based Bedwars mode detection for more accurate and timely context switching in-game, with temporary persistence and automatic reset on world change.

* **Style**
  * Updates Bedwars star prestige visuals to a new hex color palette with explicit chroma settings per tier, refining appearance across all prestige levels (including very high stars).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->