### PR TITLE
Add proxy-backed BedWars stat fetching support

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -54,13 +54,7 @@ object LevelheadConfig {
     }
 
     fun setApiKey(newKey: String) {
-        ensureInitialized()
-        val sanitized = newKey.trim()
-        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
-        property.set(sanitized)
-        apiKey = sanitized
-        configuration.save()
-        BedwarsFetcher.resetWarnings()
+        updateStringConfig(PROPERTY_API_KEY, API_KEY_COMMENT, newKey) { apiKey = it }
     }
 
     fun clearApiKey() {
@@ -68,30 +62,42 @@ object LevelheadConfig {
     }
 
     fun setProxyEnabled(enabled: Boolean) {
-        ensureInitialized()
-        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_PROXY_ENABLED, false, PROXY_ENABLED_COMMENT)
-        property.set(enabled)
-        proxyEnabled = enabled
-        configuration.save()
-        BedwarsFetcher.resetWarnings()
+        updateBooleanConfig(PROPERTY_PROXY_ENABLED, PROXY_ENABLED_COMMENT, enabled) { proxyEnabled = it }
     }
 
     fun setProxyBaseUrl(baseUrl: String) {
+        updateStringConfig(PROPERTY_PROXY_BASE_URL, PROXY_BASE_URL_COMMENT, baseUrl) { proxyBaseUrl = it }
+    }
+
+    fun setProxyAuthToken(authToken: String) {
+        updateStringConfig(PROPERTY_PROXY_AUTH_TOKEN, PROXY_AUTH_TOKEN_COMMENT, authToken) { proxyAuthToken = it }
+    }
+
+    private fun updateStringConfig(
+        key: String,
+        comment: String,
+        value: String,
+        setter: (String) -> Unit,
+    ) {
         ensureInitialized()
-        val sanitized = baseUrl.trim()
-        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_PROXY_BASE_URL, "", PROXY_BASE_URL_COMMENT)
+        val sanitized = value.trim()
+        val property = configuration.get(CATEGORY_GENERAL, key, "", comment)
         property.set(sanitized)
-        proxyBaseUrl = sanitized
+        setter(sanitized)
         configuration.save()
         BedwarsFetcher.resetWarnings()
     }
 
-    fun setProxyAuthToken(authToken: String) {
+    private fun updateBooleanConfig(
+        key: String,
+        comment: String,
+        value: Boolean,
+        setter: (Boolean) -> Unit,
+    ) {
         ensureInitialized()
-        val sanitized = authToken.trim()
-        val property = configuration.get(CATEGORY_GENERAL, PROPERTY_PROXY_AUTH_TOKEN, "", PROXY_AUTH_TOKEN_COMMENT)
-        property.set(sanitized)
-        proxyAuthToken = sanitized
+        val property = configuration.get(CATEGORY_GENERAL, key, false, comment)
+        property.set(value)
+        setter(value)
         configuration.save()
         BedwarsFetcher.resetWarnings()
     }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/BedwarsStar.kt
@@ -69,23 +69,7 @@ object BedwarsStar {
     fun extractExperience(player: JsonObject?): Long? {
         player ?: return null
 
-        BedwarsFetcher.parseBedwarsExperience(player)?.let { return it }
-
-        val statsElement = player.get("stats") ?: return null
-        if (!statsElement.isJsonObject) return null
-        val stats = statsElement.asJsonObject
-
-        val bedwarsElement = stats.get("Bedwars") ?: return null
-        if (!bedwarsElement.isJsonObject) return null
-        val bedwars = bedwarsElement.asJsonObject
-
-        val experienceEntry = bedwars.entrySet()
-            .firstOrNull { (key, _) ->
-                key.equals("Experience", ignoreCase = true) || key.equals("bedwars_experience", ignoreCase = true)
-            }
-            ?: return null
-
-        return kotlin.runCatching { experienceEntry.value.asLong }.getOrNull()
+        return BedwarsFetcher.parseBedwarsExperience(player)
     }
 
     fun calculateStar(experience: Long): Int {


### PR DESCRIPTION
## Summary
- add proxy configuration options for the BedWars proxy backend and persist them alongside the existing API key
- update the Bedwars fetcher to call the proxy when configured, handle proxy-specific errors, and fall back to Hypixel otherwise
- share a unified BedWars experience parser that supports both proxy and Hypixel response shapes

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_b_68eeaabc95d0832db8cd8f2be8f5a440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional proxy support for fetching BedWars data with configurable base URL and auth token.
  - Settings to enable/disable proxy and manage proxy credentials; requests auto-route when enabled.

- Bug Fixes
  - More resilient parsing of BedWars experience across varied response formats.
  - Safer handling when player data is missing to prevent errors.
  - Clearer, rate-limited warnings for invalid tokens and network issues.

- Refactor
  - Streamlined configuration loading and centralized update logic for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->