### PR TITLE
Fix config parsing and clarify tag centering

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
@@ -34,7 +34,9 @@ class DisplayManager(val file: File) {
                 file.createNewFile()
                 shouldSaveCopyNow = true
             }
-            val source = jsonParser.parse(FileUtils.readFileToString(file, StandardCharsets.UTF_8)).runCatching { asJsonObject }.getOrElse { JsonObject() }
+            val source = runCatching {
+                jsonParser.parse(FileUtils.readFileToString(file, StandardCharsets.UTF_8)).asJsonObject
+            }.getOrElse { JsonObject() }
             if (source.has("master")) {
                 config = gson.fromJson(source["master"].asJsonObject, MasterConfig::class.java)
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/render/AboveHeadRender.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/render/AboveHeadRender.kt
@@ -93,7 +93,7 @@ object AboveHeadRender {
     }
 
     private fun renderString(renderer: FontRenderer, tag: LevelheadTag) {
-        var x = -renderer.getStringWidth(tag.getString()) shr 1
+        var x = -(renderer.getStringWidth(tag.getString()) shr 1)
         //Render header
         render(renderer, tag.header, x)
         x += renderer.getStringWidth(tag.header.value)


### PR DESCRIPTION
## Summary
- guard DisplayManager config loading with a top-level runCatching to handle parse failures
- clarify AboveHeadRender centering math by applying negation after the shift

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f098a2fef8832d922a974e37630d9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling structure to enhance code organization while preserving existing functionality.

* **Style**
  * Applied formatting refinements to improve code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->