### PR TITLE
Align cache policy, metrics, and client UX

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.8.0",
         "dotenv": "^16.5.0",
         "express": "^4.21.0",
-        "pg": "^8.13.1"
+        "pg": "^8.13.1",
+        "prom-client": "^15.1.2"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -60,6 +61,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -336,6 +346,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1421,6 +1437,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1755,6 +1784,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/to-regex-range": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "axios": "^1.8.0",
     "pg": "^8.13.1",
     "dotenv": "^16.5.0",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "prom-client": "^15.1.2"
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -48,11 +48,18 @@ export const HYPIXEL_API_BASE_URL = process.env.HYPIXEL_API_BASE_URL ?? 'https:/
 
 export const CLOUD_FLARE_TUNNEL = process.env.CLOUDFLARE_TUNNEL ?? '';
 
-const defaultCacheTtl = 2 * 60 * 60 * 1000;
+const defaultCacheTtl = 45 * 60 * 1000;
 const rawCacheTtl = parseIntEnv('CACHE_TTL_MS', defaultCacheTtl);
-const minimumCacheTtl = 60 * 60 * 1000;
-const maximumCacheTtl = 3 * 60 * 60 * 1000;
+const minimumCacheTtl = 30 * 60 * 1000;
+const maximumCacheTtl = 60 * 60 * 1000;
 
 export const CACHE_TTL_MS = Math.min(Math.max(rawCacheTtl, minimumCacheTtl), maximumCacheTtl);
+
+export const CACHE_DB_POOL_MIN = parseIntEnv('CACHE_DB_POOL_MIN', 0);
+export const CACHE_DB_POOL_MAX = parseIntEnv('CACHE_DB_POOL_MAX', 10);
+
+export const HYPIXEL_TIMEOUT_MS = parseIntEnv('HYPIXEL_TIMEOUT_MS', 5 * 1000);
+export const HYPIXEL_RETRY_DELAY_MIN_MS = parseIntEnv('HYPIXEL_RETRY_DELAY_MIN_MS', 50);
+export const HYPIXEL_RETRY_DELAY_MAX_MS = parseIntEnv('HYPIXEL_RETRY_DELAY_MAX_MS', 150);
 
 export const CACHE_DB_URL = requiredEnv('CACHE_DB_URL');

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,15 +1,70 @@
 import express from 'express';
 import playerRouter from './routes/player';
 import { HttpError } from './util/httpError';
-import { SERVER_HOST, SERVER_PORT, CLOUD_FLARE_TUNNEL } from './config';
-import { purgeExpiredEntries, closeCache } from './services/cache';
+import {
+  SERVER_HOST,
+  SERVER_PORT,
+  CLOUD_FLARE_TUNNEL,
+  CACHE_DB_POOL_MAX,
+  CACHE_DB_POOL_MIN,
+} from './config';
+import { purgeExpiredEntries, closeCache, pool as cachePool } from './services/cache';
+import { observeRequest, registry } from './services/metrics';
+import { checkHypixelReachability } from './services/hypixel';
 
 const app = express();
 
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(express.json({ limit: '64kb' }));
+
+app.use((req, res, next) => {
+  const start = process.hrtime.bigint();
+  res.on('finish', () => {
+    const end = process.hrtime.bigint();
+    const durationSeconds = Number(end - start) / 1_000_000_000;
+    const routeLabel =
+      typeof res.locals.metricsRoute === 'string'
+        ? res.locals.metricsRoute
+        : req.baseUrl
+          ? `${req.baseUrl}${req.route?.path ?? ''}`
+          : req.route?.path ?? req.path;
+    observeRequest(req.method, routeLabel, res.statusCode, durationSeconds);
+  });
+  next();
+});
+
 app.use('/api/player', playerRouter);
+
+app.get('/healthz', async (_req, res) => {
+  res.locals.metricsRoute = '/healthz';
+  const [dbHealthy, hypixelHealthy] = await Promise.all([
+    cachePool
+      .query('SELECT 1')
+      .then(() => true)
+      .catch((error) => {
+        console.error('Database health check failed', error);
+        return false;
+      }),
+    checkHypixelReachability(),
+  ]);
+
+  const healthy = dbHealthy && hypixelHealthy;
+  res.status(healthy ? 200 : 503).json({
+    status: healthy ? 'ok' : 'degraded',
+    checks: {
+      database: dbHealthy,
+      hypixel: hypixelHealthy,
+    },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.get('/metrics', async (_req, res) => {
+  res.locals.metricsRoute = '/metrics';
+  res.set('Content-Type', registry.contentType);
+  res.send(await registry.metrics());
+});
 
 void purgeExpiredEntries().catch((error) => {
   console.error('Failed to purge expired cache entries', error);
@@ -34,6 +89,7 @@ app.use((err: unknown, _req: express.Request, res: express.Response, _next: expr
 const server = app.listen(SERVER_PORT, SERVER_HOST, () => {
   const location = CLOUD_FLARE_TUNNEL || `http://${SERVER_HOST}:${SERVER_PORT}`;
   console.log(`Levelhead proxy listening at ${location}`);
+  console.log(`Cache DB pool configured with min=${CACHE_DB_POOL_MIN} max=${CACHE_DB_POOL_MAX}.`);
 });
 
 let shuttingDown = false;
@@ -49,7 +105,7 @@ function safeCloseCache(): Promise<void> {
   return cacheClosePromise;
 }
 
-function shutdown(signal: NodeJS.Signals): void {
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (shuttingDown) {
     return;
   }
@@ -62,28 +118,36 @@ function shutdown(signal: NodeJS.Signals): void {
     console.error('Forcing shutdown.');
     void safeCloseCache();
     process.exit(1);
-  }, 5000);
+  }, 15000);
   forcedShutdown.unref();
 
-  server.close((err?: Error) => {
-    if (err) {
-      console.error('Error closing HTTP server', err);
-      process.exitCode = 1;
-    }
+  try {
+    await new Promise<void>((resolve) => {
+      server.close((err?: Error) => {
+        if (err) {
+          console.error('Error closing HTTP server', err);
+          process.exitCode = 1;
+        }
 
+        resolve();
+      });
+    });
+  } finally {
     safeCloseCache().finally(() => {
       clearTimeout(forcedShutdown);
 
       const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
       process.exit(exitCode);
     });
-  });
+  }
 }
 
 const shutdownSignals = ['SIGINT', 'SIGTERM'] as const;
 
 shutdownSignals.forEach((signal) => {
-  process.on(signal, () => shutdown(signal));
+  process.on(signal, () => {
+    void shutdown(signal);
+  });
 });
 
 process.on('exit', () => {

--- a/backend/src/routes/player.ts
+++ b/backend/src/routes/player.ts
@@ -3,14 +3,60 @@ import { requireModHandshake } from '../middleware/auth';
 import { enforceRateLimit } from '../middleware/rateLimit';
 import { resolvePlayer } from '../services/player';
 
+function parseIfModifiedSince(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function shouldReturnNotModified(
+  clientEtag: string | undefined,
+  clientModifiedSince: number | undefined,
+  serverEtag: string | null,
+  serverLastModified: number | null,
+): boolean {
+  if (clientEtag && serverEtag) {
+    return clientEtag === serverEtag;
+  }
+
+  if (!clientEtag && clientModifiedSince && serverLastModified) {
+    return serverLastModified <= clientModifiedSince;
+  }
+
+  return false;
+}
+
 const router = Router();
 
 router.get('/:identifier', requireModHandshake, enforceRateLimit, async (req, res, next) => {
   const { identifier } = req.params;
+  const ifNoneMatch = req.header('if-none-match')?.trim();
+  const ifModifiedSince = parseIfModifiedSince(req.header('if-modified-since'));
+  res.locals.metricsRoute = '/api/player/:identifier';
 
   try {
-    const payload = await resolvePlayer(identifier);
-    res.json(payload);
+    const resolved = await resolvePlayer(identifier, {
+      etag: ifNoneMatch,
+      lastModified: ifModifiedSince,
+    });
+
+    if (shouldReturnNotModified(ifNoneMatch, ifModifiedSince, resolved.etag, resolved.lastModified)) {
+      res.status(304).end();
+      return;
+    }
+
+    if (resolved.etag) {
+      res.set('ETag', resolved.etag);
+    }
+
+    if (resolved.lastModified) {
+      res.set('Last-Modified', new Date(resolved.lastModified).toUTCString());
+    }
+
+    res.json(resolved.payload);
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -1,0 +1,89 @@
+import client from 'prom-client';
+
+export const registry = new client.Registry();
+
+client.collectDefaultMetrics({ register: registry });
+
+export const httpRequestsTotal = new client.Counter({
+  name: 'levelhead_http_requests_total',
+  help: 'Total HTTP requests received by the Levelhead backend.',
+  labelNames: ['method', 'route', 'status'],
+  registers: [registry],
+});
+
+export const httpRequestDurationSeconds = new client.Histogram({
+  name: 'levelhead_http_request_duration_seconds',
+  help: 'HTTP request duration in seconds.',
+  labelNames: ['method', 'route'],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+  registers: [registry],
+});
+
+export const httpResponsesByStatusClassTotal = new client.Counter({
+  name: 'levelhead_http_responses_by_status_class_total',
+  help: 'HTTP responses grouped by status class.',
+  labelNames: ['method', 'route', 'status_class'],
+  registers: [registry],
+});
+
+export const cacheHitsTotal = new client.Counter({
+  name: 'levelhead_cache_hits_total',
+  help: 'Number of cache hits served.',
+  registers: [registry],
+});
+
+export const cacheMissesTotal = new client.Counter({
+  name: 'levelhead_cache_misses_total',
+  help: 'Number of cache misses encountered.',
+  registers: [registry],
+});
+
+const cacheHitRatioGauge = new client.Gauge({
+  name: 'levelhead_cache_hit_ratio',
+  help: 'Ratio of cache hits to total lookups.',
+  registers: [registry],
+});
+
+export const rateLimitBlocksTotal = new client.Counter({
+  name: 'levelhead_rate_limit_blocks_total',
+  help: 'Number of requests blocked by the proxy rate limiter.',
+  registers: [registry],
+});
+
+let cacheHits = 0;
+let cacheMisses = 0;
+
+function updateCacheRatio(): void {
+  const total = cacheHits + cacheMisses;
+  if (total === 0) {
+    cacheHitRatioGauge.set(0);
+    return;
+  }
+
+  cacheHitRatioGauge.set(cacheHits / total);
+}
+
+export function recordCacheHit(): void {
+  cacheHitsTotal.inc();
+  cacheHits += 1;
+  updateCacheRatio();
+}
+
+export function recordCacheMiss(): void {
+  cacheMissesTotal.inc();
+  cacheMisses += 1;
+  updateCacheRatio();
+}
+
+export function observeRequest(
+  method: string,
+  route: string,
+  status: number,
+  durationSeconds: number,
+): void {
+  httpRequestsTotal.inc({ method, route, status: status.toString() });
+  httpRequestDurationSeconds.observe({ method, route }, durationSeconds);
+  const classIndex = Math.trunc(status / 100);
+  const label = classIndex > 0 ? `${classIndex}xx` : 'other';
+  httpResponsesByStatusClassTotal.inc({ method, route, status_class: label });
+}

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -8,7 +8,7 @@ import gg.essential.api.commands.Command
 import gg.essential.api.commands.DefaultHandler
 import gg.essential.api.commands.SubCommand
 import gg.essential.universal.ChatColor
-import kotlinx.coroutines.cancelChildren
+import java.util.Locale
 
 class LevelheadCommand : Command("levelhead") {
 
@@ -66,7 +66,7 @@ class LevelheadCommand : Command("levelhead") {
 
     @SubCommand(value = "reload")
     fun handleReload() {
-        Levelhead.scope.coroutineContext.cancelChildren()
+        Levelhead.resetWorldCoroutines()
         Levelhead.rateLimiter.resetState()
         Levelhead.displayManager.clearCache()
         EssentialAPI.getMinecraftUtil().sendMessage(
@@ -75,10 +75,50 @@ class LevelheadCommand : Command("levelhead") {
         )
     }
 
+    @SubCommand(value = "status")
+    fun handleStatus() {
+        val snapshot = Levelhead.statusSnapshot()
+        val proxyStatus = when {
+            !snapshot.proxyEnabled -> "${ChatColor.GRAY}disabled"
+            snapshot.proxyConfigured -> "${ChatColor.GREEN}configured"
+            else -> "${ChatColor.RED}missing config"
+        }
+        val lastAttempt = formatAge(snapshot.lastAttemptAgeMillis)
+        val lastSuccess = formatAge(snapshot.lastSuccessAgeMillis)
+        val rateReset = formatAge(snapshot.rateLimitResetMillis)
+
+        sendStatus("${ChatColor.GREEN}Status snapshot:")
+        sendStatus("${ChatColor.YELLOW}Proxy: $proxyStatus")
+        sendStatus("${ChatColor.YELLOW}Cache size: ${ChatColor.GOLD}${snapshot.cacheSize}")
+        sendStatus("${ChatColor.YELLOW}Last request: ${ChatColor.GOLD}$lastAttempt${ChatColor.YELLOW} ago")
+        sendStatus("${ChatColor.YELLOW}Last success: ${ChatColor.GOLD}$lastSuccess${ChatColor.YELLOW} ago")
+        sendStatus(
+            "${ChatColor.YELLOW}Rate limit: ${ChatColor.GOLD}${snapshot.rateLimitRemaining}${ChatColor.YELLOW} remaining, resets in ${ChatColor.GOLD}$rateReset"
+        )
+    }
+
     private fun resetBedwarsFetcher() {
-        Levelhead.scope.coroutineContext.cancelChildren()
+        Levelhead.resetWorldCoroutines()
         Levelhead.rateLimiter.resetState()
         Levelhead.displayManager.clearCachesWithoutRefetch()
         BedwarsFetcher.resetWarnings()
+    }
+
+    private fun sendStatus(message: String) {
+        EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", message)
+    }
+
+    private fun formatAge(ageMillis: Long?): String {
+        ageMillis ?: return "never"
+        val totalSeconds = (ageMillis / 1000).coerceAtLeast(0)
+        val seconds = (totalSeconds % 60).toInt()
+        val minutesTotal = totalSeconds / 60
+        val minutes = (minutesTotal % 60).toInt()
+        val hours = (minutesTotal / 60).toInt()
+        return when {
+            hours > 0 -> String.format(Locale.ROOT, "%dh %dm", hours, minutes)
+            minutes > 0 -> String.format(Locale.ROOT, "%dm %ds", minutes, seconds)
+            else -> String.format(Locale.ROOT, "%ds", seconds)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- tighten backend cache TTL configuration, add DB pool controls, expose Prometheus metrics, and serve health/metrics endpoints
- rework player caching to support conditional requests, short-lived memoization, and Hypixel retry logic while instrumenting rate-limit blocks
- update the mod to manage world coroutine scopes, add jitter/backoff, improve proxy validation, and provide an in-game status command

## Testing
- npm run build
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_b_68f2614f4814832db9904c4a18c4f798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check and metrics monitoring endpoints for system visibility.
  * Added in-game status command displaying proxy health, cache metrics, and rate limiter state.
  * Enabled HTTP caching support with conditional request headers for improved performance.

* **Improvements**
  * Enhanced API request handling with improved retry logic and timeout configuration.
  * Optimized cache management with adjusted time-to-live defaults.
  * Better error categorization and handling for network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->