### PR TITLE
Improve backend metrics and cache handling

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.8.0",
         "dotenv": "^16.5.0",
         "express": "^4.21.0",
-        "pg": "^8.13.1"
+        "pg": "^8.13.1",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -60,6 +61,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -336,6 +346,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1421,6 +1437,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1755,6 +1784,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/to-regex-range": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,14 +9,15 @@
   },
   "dependencies": {
     "axios": "^1.8.0",
-    "pg": "^8.13.1",
     "dotenv": "^16.5.0",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "pg": "^8.13.1",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.10",
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.30",
+    "@types/pg": "^8.11.10",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,12 +3,15 @@ import playerRouter from './routes/player';
 import { HttpError } from './util/httpError';
 import { SERVER_HOST, SERVER_PORT, CLOUD_FLARE_TUNNEL } from './config';
 import { purgeExpiredEntries, closeCache } from './services/cache';
+import { metricsHandler, metricsMiddleware } from './services/metrics';
 
 const app = express();
 
 app.disable('x-powered-by');
 app.set('trust proxy', 1);
 app.use(express.json({ limit: '64kb' }));
+app.use(metricsMiddleware);
+app.get('/metrics', metricsHandler);
 app.use('/api/player', playerRouter);
 
 void purgeExpiredEntries().catch((error) => {

--- a/backend/src/services/hypixel.ts
+++ b/backend/src/services/hypixel.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AxiosResponseHeaders, RawAxiosResponseHeaders } from 'axios';
 import { HYPIXEL_API_BASE_URL, HYPIXEL_API_KEY } from '../config';
 import { HttpError } from '../util/httpError';
 
@@ -8,6 +9,7 @@ const hypixelClient = axios.create({
   headers: {
     'User-Agent': 'Levelhead-Proxy/1.0',
   },
+  validateStatus: (status) => status >= 200 && status < 400,
 });
 
 export interface HypixelPlayerResponse {
@@ -38,39 +40,89 @@ export interface ProxyPlayerPayload {
   display?: string;
 }
 
-export async function fetchHypixelPlayer(uuid: string): Promise<ProxyPlayerPayload> {
+export interface HypixelFetchOptions {
+  etag?: string;
+  lastModified?: string;
+}
+
+export interface HypixelPlayerFetchResult {
+  payload?: ProxyPlayerPayload;
+  etag?: string;
+  lastModified?: string;
+  notModified: boolean;
+}
+
+function readHeader(
+  headers: RawAxiosResponseHeaders | AxiosResponseHeaders,
+  name: string,
+): string | undefined {
+  const headerValue = headers[name.toLowerCase() as keyof typeof headers];
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return headerValue ?? undefined;
+}
+
+function shapePlayerPayload(response: HypixelPlayerResponse): ProxyPlayerPayload {
+  const bedwarsStats = response.player?.stats?.Bedwars ?? {};
+  const statsRecord = bedwarsStats as Record<string, unknown>;
+  const experience = statsRecord['bedwars_experience'] ?? statsRecord['Experience'];
+
+  const shapedStats: Record<string, unknown> = {
+    ...statsRecord,
+    ...(experience !== undefined ? { bedwars_experience: experience, Experience: experience } : {}),
+  };
+
+  return {
+    success: true,
+    data: {
+      bedwars: shapedStats,
+    },
+    bedwars: shapedStats,
+    player: {
+      stats: {
+        Bedwars: shapedStats,
+      },
+    },
+  };
+}
+
+export async function fetchHypixelPlayer(
+  uuid: string,
+  options: HypixelFetchOptions = {},
+): Promise<HypixelPlayerFetchResult> {
   try {
     const response = await hypixelClient.get<HypixelPlayerResponse>('/v2/player', {
       params: { uuid },
       headers: {
         'API-Key': HYPIXEL_API_KEY,
+        ...(options.etag ? { 'If-None-Match': options.etag } : {}),
+        ...(options.lastModified ? { 'If-Modified-Since': options.lastModified } : {}),
       },
     });
+
+    const etag = readHeader(response.headers, 'etag');
+    const lastModified = readHeader(response.headers, 'last-modified');
+
+    if (response.status === 304) {
+      return {
+        notModified: true,
+        etag: etag ?? options.etag,
+        lastModified: lastModified ?? options.lastModified,
+      };
+    }
 
     if (!response.data.success) {
       const cause = response.data.cause ?? 'UNKNOWN_HYPIXEL_ERROR';
       throw new HttpError(502, cause, 'Hypixel returned an error response.');
     }
 
-    const bedwarsStats = response.data.player?.stats?.Bedwars ?? {};
-    const experience = (bedwarsStats as any).bedwars_experience ?? (bedwarsStats as any).Experience;
-
-    const shapedStats: Record<string, unknown> = {
-      ...bedwarsStats,
-      ...(experience !== undefined ? { bedwars_experience: experience, Experience: experience } : {}),
-    };
-
     return {
-      success: true,
-      data: {
-        bedwars: shapedStats,
-      },
-      bedwars: shapedStats,
-      player: {
-        stats: {
-          Bedwars: shapedStats,
-        },
-      },
+      payload: shapePlayerPayload(response.data),
+      etag,
+      lastModified,
+      notModified: false,
     };
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -1,0 +1,150 @@
+import type { NextFunction, Request, Response } from 'express';
+import client, { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+collectDefaultMetrics({ register: client.register });
+
+const httpRequestDurationHistogram = new Histogram({
+  name: 'levelhead_http_request_duration_seconds',
+  help: 'Duration of HTTP requests handled by the Levelhead backend in seconds.',
+  labelNames: ['method', 'route', 'status'],
+  buckets: [0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+const cacheHitsTotal = new Counter({
+  name: 'levelhead_cache_hits_total',
+  help: 'Total number of cache hits.',
+  labelNames: ['cache'],
+});
+
+const cacheMissesTotal = new Counter({
+  name: 'levelhead_cache_misses_total',
+  help: 'Total number of cache misses.',
+  labelNames: ['cache'],
+});
+
+const cacheHitRatioGauge = new Gauge({
+  name: 'levelhead_cache_hit_ratio',
+  help: 'Cache hit ratio derived from total hits and misses.',
+  labelNames: ['cache'],
+  async collect() {
+    this.reset();
+    const [hitMetrics, missMetrics] = await Promise.all([cacheHitsTotal.get(), cacheMissesTotal.get()]);
+
+    const entries = new Map<string, { labels: Record<string, string>; hits: number; misses: number }>();
+
+    for (const metric of hitMetrics.values ?? []) {
+      const labels = normalizeLabels(metric.labels);
+      const key = serializeLabels(labels);
+      entries.set(key, {
+        labels,
+        hits: metric.value,
+        misses: entries.get(key)?.misses ?? 0,
+      });
+    }
+
+    for (const metric of missMetrics.values ?? []) {
+      const labels = normalizeLabels(metric.labels);
+      const key = serializeLabels(labels);
+      const entry = entries.get(key);
+      if (entry) {
+        entry.misses = metric.value;
+      } else {
+        entries.set(key, {
+          labels,
+          hits: 0,
+          misses: metric.value,
+        });
+      }
+    }
+
+    for (const entry of entries.values()) {
+      const total = entry.hits + entry.misses;
+      const ratio = total === 0 ? 0 : entry.hits / total;
+      this.set(entry.labels, ratio);
+    }
+  },
+});
+
+function normalizeLabels(labels?: Record<string, string | number | undefined>): Record<string, string> {
+  if (!labels) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(labels)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    normalized[key] = String(value);
+  }
+
+  return normalized;
+}
+
+function serializeLabels(labels: Record<string, string>): string {
+  const entries = Object.entries(labels).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return JSON.stringify(entries);
+}
+
+function getRoutePath(routePath: unknown): string | null {
+  if (!routePath) {
+    return null;
+  }
+
+  if (typeof routePath === 'string') {
+    return routePath;
+  }
+
+  if (Array.isArray(routePath)) {
+    return routePath[0] ?? null;
+  }
+
+  return null;
+}
+
+function normalizeRouteTemplate(req: Request): string {
+  const base = req.baseUrl ?? '';
+  const path = req.route ? getRoutePath(req.route.path) : null;
+
+  if (path) {
+    return `${base}${path}` || 'unknown_route';
+  }
+
+  if (base) {
+    return base;
+  }
+
+  return 'unknown_route';
+}
+
+export function metricsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const endTimer = httpRequestDurationHistogram.startTimer();
+
+  res.once('finish', () => {
+    const route = normalizeRouteTemplate(req);
+    endTimer({
+      method: req.method,
+      route,
+      status: String(res.statusCode),
+    });
+  });
+
+  next();
+}
+
+export async function metricsHandler(_req: Request, res: Response): Promise<void> {
+  const registry: Registry = client.register;
+  res.setHeader('Content-Type', registry.contentType);
+  res.end(await registry.metrics());
+}
+
+export function recordCacheHit(cache: string): void {
+  cacheHitsTotal.inc({ cache });
+}
+
+export function recordCacheMiss(cache: string): void {
+  cacheMissesTotal.inc({ cache });
+}
+
+export const metricsRegistry = client.register;

--- a/backend/src/services/player.ts
+++ b/backend/src/services/player.ts
@@ -1,14 +1,84 @@
 import { CACHE_TTL_MS } from '../config';
 import { HttpError } from '../util/httpError';
 import { getCachedPayload, setCachedPayload } from './cache';
-import { fetchHypixelPlayer, ProxyPlayerPayload } from './hypixel';
+import {
+  fetchHypixelPlayer,
+  HypixelFetchOptions,
+  HypixelPlayerFetchResult,
+  ProxyPlayerPayload,
+} from './hypixel';
 import { lookupProfileByUsername } from './mojang';
+import { recordCacheHit, recordCacheMiss } from './metrics';
 
 const uuidRegex = /^[0-9a-f]{32}$/i;
 const ignRegex = /^[a-zA-Z0-9_]{1,16}$/;
 
+const PLAYER_UUID_CACHE_LABEL = 'player_uuid';
+const PLAYER_IGN_CACHE_LABEL = 'player_ign';
+
+interface CachedPlayerEntry {
+  value: ProxyPlayerPayload;
+  etag?: string;
+  lastModified?: string;
+}
+
+interface ResolvedPlayer {
+  payload: ProxyPlayerPayload;
+  etag?: string;
+  lastModified?: string;
+}
+
+interface MemoizedEntry {
+  expiresAt: number;
+  resolved: ResolvedPlayer;
+}
+
+const memoizedPlayers = new Map<string, MemoizedEntry>();
+
+function normalizeCacheEntry(
+  entry: CachedPlayerEntry | ProxyPlayerPayload | null,
+): CachedPlayerEntry | null {
+  if (!entry) {
+    return null;
+  }
+
+  if (typeof entry === 'object' && entry !== null && 'value' in entry) {
+    const candidate = entry as CachedPlayerEntry;
+    if (candidate.value) {
+      return candidate;
+    }
+
+    return null;
+  }
+
+  return {
+    value: entry as ProxyPlayerPayload,
+  };
+}
+
 function buildCacheKey(prefix: string, value: string): string {
   return `${prefix}:${value}`;
+}
+
+function getMemoized(uuid: string): ResolvedPlayer | null {
+  const entry = memoizedPlayers.get(uuid);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    memoizedPlayers.delete(uuid);
+    return null;
+  }
+
+  return entry.resolved;
+}
+
+function setMemoized(uuid: string, resolved: ResolvedPlayer): void {
+  memoizedPlayers.set(uuid, {
+    resolved,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
 }
 
 function buildNickedPayload(): ProxyPlayerPayload {
@@ -35,48 +105,124 @@ function buildNickedPayload(): ProxyPlayerPayload {
   };
 }
 
-async function fetchByUuid(uuid: string): Promise<ProxyPlayerPayload> {
+async function fetchByUuid(uuid: string): Promise<ResolvedPlayer> {
   const normalizedUuid = uuid.toLowerCase();
-  const cacheKey = buildCacheKey('player', normalizedUuid);
-
-  const cached = await getCachedPayload<ProxyPlayerPayload>(cacheKey);
-  if (cached) {
-    return cached;
+  const memoized = getMemoized(normalizedUuid);
+  if (memoized) {
+    return memoized;
   }
 
-  const payload = await fetchHypixelPlayer(normalizedUuid);
-  await setCachedPayload(cacheKey, payload, CACHE_TTL_MS);
-  return payload;
+  const cacheKey = buildCacheKey('player', normalizedUuid);
+  const rawCacheEntry = await getCachedPayload<CachedPlayerEntry | ProxyPlayerPayload>(cacheKey);
+  const cacheEntry = normalizeCacheEntry(rawCacheEntry);
+  const validators: HypixelFetchOptions = {};
+
+  if (cacheEntry) {
+    recordCacheHit(PLAYER_UUID_CACHE_LABEL);
+    if (cacheEntry.etag) {
+      validators.etag = cacheEntry.etag;
+    }
+
+    if (cacheEntry.lastModified) {
+      validators.lastModified = cacheEntry.lastModified;
+    }
+  } else {
+    recordCacheMiss(PLAYER_UUID_CACHE_LABEL);
+  }
+
+  let response: HypixelPlayerFetchResult = await fetchHypixelPlayer(normalizedUuid, validators);
+
+  if (response.notModified) {
+    if (!cacheEntry) {
+      response = await fetchHypixelPlayer(normalizedUuid);
+    } else {
+      const resolved: ResolvedPlayer = {
+        payload: cacheEntry.value,
+        etag: response.etag ?? cacheEntry.etag,
+        lastModified: response.lastModified ?? cacheEntry.lastModified,
+      };
+      await setCachedPayload(cacheKey, {
+        value: resolved.payload,
+        etag: resolved.etag,
+        lastModified: resolved.lastModified,
+      }, CACHE_TTL_MS);
+      setMemoized(normalizedUuid, resolved);
+      return resolved;
+    }
+  }
+
+  if (!response.payload) {
+    throw new HttpError(502, 'HYPIXEL_EMPTY_PAYLOAD', 'Hypixel returned an empty player payload.');
+  }
+
+  const resolved: ResolvedPlayer = {
+    payload: response.payload,
+    etag: response.etag,
+    lastModified: response.lastModified,
+  };
+
+  await setCachedPayload(cacheKey, {
+    value: resolved.payload,
+    etag: resolved.etag,
+    lastModified: resolved.lastModified,
+  }, CACHE_TTL_MS);
+  setMemoized(normalizedUuid, resolved);
+  return resolved;
 }
 
-async function fetchByIgn(ign: string): Promise<ProxyPlayerPayload> {
+async function fetchByIgn(ign: string): Promise<ResolvedPlayer> {
   const normalizedIgn = ign.toLowerCase();
   const ignCacheKey = buildCacheKey('ign', normalizedIgn);
 
-  const cached = await getCachedPayload<ProxyPlayerPayload>(ignCacheKey);
-  if (cached) {
-    return cached;
+  const rawCacheEntry = await getCachedPayload<CachedPlayerEntry | ProxyPlayerPayload>(ignCacheKey);
+  const cacheEntry = normalizeCacheEntry(rawCacheEntry);
+  if (cacheEntry) {
+    recordCacheHit(PLAYER_IGN_CACHE_LABEL);
+    return {
+      payload: cacheEntry.value,
+      etag: cacheEntry.etag,
+      lastModified: cacheEntry.lastModified,
+    };
   }
+
+  recordCacheMiss(PLAYER_IGN_CACHE_LABEL);
 
   const profile = await lookupProfileByUsername(ign);
   if (!profile) {
     const nickedPayload = buildNickedPayload();
-    await setCachedPayload(ignCacheKey, nickedPayload, CACHE_TTL_MS);
-    return nickedPayload;
+    const resolved: ResolvedPlayer = { payload: nickedPayload };
+    await setCachedPayload(
+      ignCacheKey,
+      {
+        value: resolved.payload,
+      },
+      CACHE_TTL_MS,
+    );
+    return resolved;
   }
 
-  const payload = await fetchByUuid(profile.id);
-  await setCachedPayload(ignCacheKey, payload, CACHE_TTL_MS);
-  return payload;
+  const resolvedPlayer = await fetchByUuid(profile.id);
+  await setCachedPayload(
+    ignCacheKey,
+    {
+      value: resolvedPlayer.payload,
+      etag: resolvedPlayer.etag,
+      lastModified: resolvedPlayer.lastModified,
+    },
+    CACHE_TTL_MS,
+  );
+  return resolvedPlayer;
 }
 
 export async function resolvePlayer(identifier: string): Promise<ProxyPlayerPayload> {
   if (uuidRegex.test(identifier)) {
-    return fetchByUuid(identifier);
+    const resolved = await fetchByUuid(identifier);
+    return resolved.payload;
   }
 
   if (ignRegex.test(identifier)) {
-    return fetchByIgn(identifier);
+    const resolved = await fetchByIgn(identifier);
+    return resolved.payload;
   }
 
   throw new HttpError(

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -101,6 +101,7 @@ object Levelhead {
         BedwarsFetcher.resetWarnings()
         scope.coroutineContext.cancelChildren()
         rateLimiter.resetState()
+        resetRateLimiterNotification()
         displayManager.clearCachesWithoutRefetch()
         clearCachedStars()
         scope.launch { displayManager.requestAllDisplays() }


### PR DESCRIPTION
## Summary
- add Prometheus metrics middleware and expose a metrics endpoint with normalized route labels
- update Hypixel/player services to use conditional requests safely, refresh cache metadata, and compute cache hit ratios via custom collection
- ensure the rate limiter notification guard resets on server join for the client mod

## Testing
- npm run build
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_b_68f35135f564832d999e53021a070050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent caching for player data with automatic expiration, significantly improving response times and reducing unnecessary API requests
  * Added HTTP caching optimization using industry-standard headers to enable more efficient server communication and data transfer
  * Enhanced server join experience with improved rate limiter notification state management for smoother transitions between servers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->