### PR TITLE
Add Modrinth draft publishing pipeline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,13 @@
+import com.modrinth.minotaur.TaskModrinthUpload
 import gg.essential.gradle.util.noServerRunConfigs
+import net.fabricmc.loom.task.RemapJarTask
+import org.gradle.api.GradleException
 
 plugins {
     kotlin("jvm")
     id("gg.essential.multi-version")
     id("gg.essential.defaults")
+    id("com.modrinth.minotaur") version "2.7.5"
 }
 
 val modGroup: String by project
@@ -59,4 +63,31 @@ tasks.jar {
         "TweakOrder" to "0",
         "MixinConfigs" to "mixins.levelhead.json"
     ))
+}
+
+modrinth {
+    token.set(providers.environmentVariable("MODRINTH_TOKEN"))
+    projectId.set("bedwars-levelhead")
+    versionNumber.set("${project.version}-${platform.mcVersionStr}")
+    versionName.set("Levelhead ${platform.mcVersionStr} ${project.version}")
+    changelog.set(providers.provider {
+        val branch = System.getenv("BRANCH_NAME") ?: "local"
+        val build = System.getenv("BUILD_ID") ?: "local"
+        "Automated build $build on branch $branch."
+    })
+    file.set(tasks.named<RemapJarTask>("remapJar").flatMap { it.archiveFile })
+    gameVersions.set(listOf(platform.mcVersionStr))
+    loaders.set(listOf("forge"))
+    versionType.set("release")
+    detectLoaders.set(false)
+}
+
+tasks.named<TaskModrinthUpload>("modrinth") {
+    dependsOn(tasks.named("remapJar"))
+    outputs.upToDateWhen { false }
+    doFirst {
+        if (System.getenv("MODRINTH_TOKEN").isNullOrBlank()) {
+            throw GradleException("MODRINTH_TOKEN is required to publish to Modrinth")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- apply the Modrinth Minotaur plugin to each version build and configure uploads for Bedwars Levelhead
- ensure Modrinth uploads depend on remapped jars and require the `MODRINTH_TOKEN`
- extend the Jenkins pipeline to upload with `./gradlew modrinth` and patch the resulting versions to draft status using the `:MODRINTH_TOKEN` credential

## Testing
- `./gradlew build -x test`
- `./gradlew tasks`


------
https://chatgpt.com/codex/tasks/task_b_68f39fef1840832db1bda36841d903c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing builds to Modrinth platform.

* **Chores**
  * Updated CI/CD pipeline to automate Modrinth uploads and manage draft status post-deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->