### PR TITLE
Update GitHub Actions workflow for building and uploading

### DIFF
--- a/.github/workflows/build-1-8-9.yml
+++ b/.github/workflows/build-1-8-9.yml
@@ -28,26 +28,42 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - name: Upload draft to Modrinth
+      - name: Upload 1.8.9 draft to Modrinth
         uses: Kir-Antipov/mc-publish@v3.3
         with:
           modrinth-id: JBRfBF5q
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
-          
+
           version-type: beta  # or alpha, depending on your preference
           modrinth-featured: false
-          
+
           # Automatically generate version number from commit
-          version: ${{ github.sha }}
-          name: "Draft Build - ${{ github.sha }}"
-          
+          version: 1.8.9-${{ github.sha }}
+          name: "Draft Build 1.8.9 - ${{ github.sha }}"
+
           # Specify your JAR files
-          files: |
-            versions/1.8.9/build/libs/*.jar
-            versions/1.12.2/build/libs/*.jar
-          
+          files: versions/1.8.9/build/libs/*.jar
+
           # Game versions and loaders
-          game-versions: |
-            1.8.9
-            1.12.2
+          game-versions: 1.8.9
+          loaders: forge
+
+      - name: Upload 1.12.2 draft to Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: JBRfBF5q
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          version-type: beta  # or alpha, depending on your preference
+          modrinth-featured: false
+
+          # Automatically generate version number from commit
+          version: 1.12.2-${{ github.sha }}
+          name: "Draft Build 1.12.2 - ${{ github.sha }}"
+
+          # Specify your JAR files
+          files: versions/1.12.2/build/libs/*.jar
+
+          # Game versions and loaders
+          game-versions: 1.12.2
           loaders: forge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build and deployment workflow now automatically publishes draft uploads to Modrinth on pushes to the main branch.
  * Drafts created for both 1.8.9 and 1.12.2 builds, marked as beta and not featured, with version names tied to the commit.
  * Build environment and packaging steps streamlined to ensure consistent Gradle builds prior to upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->