### PR TITLE
Align client rate limiting with server hints and add monitoring stack

### DIFF
--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -50,9 +50,15 @@ export function enforceRateLimit(req: Request, res: Response, next: NextFunction
 
   if (bucket.count >= RATE_LIMIT_MAX) {
     const retryAfterSeconds = Math.ceil((bucket.windowStartedAt + RATE_LIMIT_WINDOW_MS - now) / 1000);
-    res.set('Retry-After', retryAfterSeconds.toString());
+    const retryAfterHeader = retryAfterSeconds.toString();
+    res.set('Retry-After', retryAfterHeader);
     rateLimitBlocksTotal.inc();
-    throw new HttpError(429, 'RATE_LIMIT', `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+    throw new HttpError(
+      429,
+      'RATE_LIMIT',
+      `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`,
+      { 'Retry-After': retryAfterHeader },
+    );
   }
 
   bucket.count += 1;

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { requireModHandshake } from '../middleware/auth';
+import { clearAllCacheEntries, deleteCacheEntries } from '../services/cache';
+import { clearInMemoryPlayerCache } from '../services/player';
+import { HttpError } from '../util/httpError';
+
+const router = Router();
+
+const uuidRegex = /^[0-9a-f]{32}$/i;
+const ignRegex = /^[a-z0-9_]{1,16}$/i;
+
+function cacheKeysForIdentifier(identifier: string): string[] {
+  const normalized = identifier.toLowerCase();
+  if (uuidRegex.test(normalized)) {
+    return [`player:${normalized}`];
+  }
+
+  if (ignRegex.test(normalized)) {
+    return [`ign:${normalized}`];
+  }
+
+  return [];
+}
+
+router.post('/cache/purge', requireModHandshake, async (req, res, next) => {
+  res.locals.metricsRoute = '/api/admin/cache/purge';
+  const { identifier } = req.body ?? {};
+
+  try {
+    let purged = 0;
+    if (typeof identifier === 'string' && identifier.trim().length > 0) {
+      const keys = cacheKeysForIdentifier(identifier.trim());
+      if (keys.length === 0) {
+        throw new HttpError(400, 'INVALID_IDENTIFIER', 'Identifier must be a UUID (without dashes) or an IGN.');
+      }
+      purged = await deleteCacheEntries(keys);
+    } else {
+      purged = await clearAllCacheEntries();
+    }
+
+    clearInMemoryPlayerCache();
+
+    res.status(202).json({ success: true, purged });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -38,6 +38,13 @@ export const cacheMissesTotal = new client.Counter({
   registers: [registry],
 });
 
+export const cacheMissesByReasonTotal = new client.Counter({
+  name: 'levelhead_cache_misses_by_reason_total',
+  help: 'Number of cache misses grouped by reason.',
+  labelNames: ['reason'],
+  registers: [registry],
+});
+
 const cacheHitRatioGauge = new client.Gauge({
   name: 'levelhead_cache_hit_ratio',
   help: 'Ratio of cache hits to total lookups.',
@@ -69,8 +76,9 @@ export function recordCacheHit(): void {
   updateCacheRatio();
 }
 
-export function recordCacheMiss(): void {
+export function recordCacheMiss(reason: string = 'unknown'): void {
   cacheMissesTotal.inc();
+  cacheMissesByReasonTotal.inc({ reason });
   cacheMisses += 1;
   updateCacheRatio();
 }

--- a/backend/src/services/player.ts
+++ b/backend/src/services/player.ts
@@ -17,6 +17,11 @@ const MEMOIZED_TTL_MS = 2_000;
 
 const inFlightRequests = new Map<string, Promise<ResolvedPlayer>>();
 
+export function clearInMemoryPlayerCache(): void {
+  memoizedResults.clear();
+  inFlightRequests.clear();
+}
+
 function buildNickedPayload(): ProxyPlayerPayload {
   const display = '(nicked)';
   const bedwarsStats: Record<string, unknown> = {
@@ -117,7 +122,7 @@ async function fetchByUuid(uuid: string, conditional?: HypixelFetchOptions): Pro
 
   const payload = response.payload ?? cacheEntry?.value;
   if (!payload) {
-    recordCacheMiss();
+    recordCacheMiss('empty_payload');
     throw new HttpError(502, 'HYPIXEL_EMPTY_PAYLOAD', 'Hypixel did not return any data.');
   }
 

--- a/backend/src/util/httpError.ts
+++ b/backend/src/util/httpError.ts
@@ -1,11 +1,13 @@
 export class HttpError extends Error {
   public readonly status: number;
   public readonly causeCode: string;
+  public readonly headers?: Record<string, string>;
 
-  constructor(status: number, causeCode: string, message?: string) {
+  constructor(status: number, causeCode: string, message?: string, headers?: Record<string, string>) {
     super(message ?? causeCode);
     this.name = 'HttpError';
     this.status = status;
     this.causeCode = causeCode;
+    this.headers = headers;
   }
 }

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,12 @@
+# Monitoring stack
+
+This directory contains a lightweight Prometheus + Grafana stack for inspecting the proxy metrics exposed by `/metrics`.
+
+## Usage
+
+1. Ensure the proxy is reachable from Docker. The default Prometheus configuration points at `host.docker.internal:3000`. On Linux you may need to replace that host with the gateway IP (for example `172.17.0.1`).
+2. From this directory run `docker compose up -d`.
+3. Browse to Grafana at <http://localhost:3001> (default credentials `admin/admin`).
+4. Open the **Levelhead / Levelhead Proxy Overview** dashboard to inspect cache efficiency, request latencies, and rate-limit activity.
+
+Prometheus scrapes the proxy every 15 seconds and Grafana is pre-provisioned with a datasource and dashboard so the stack is ready immediately.

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - '9090:9090'
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - '3001:3000'
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus

--- a/monitoring/grafana/dashboards/levelhead-overview.json
+++ b/monitoring/grafana/dashboards/levelhead-overview.json
@@ -1,0 +1,120 @@
+{
+  "id": null,
+  "uid": "levelhead-overview",
+  "title": "Levelhead Proxy Overview",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "style": "dark",
+  "editable": true,
+  "gnetId": null,
+  "panels": [
+    {
+      "type": "gauge",
+      "title": "Cache Hit Ratio",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              { "value": 0, "color": "red" },
+              { "value": 0.5, "color": "orange" },
+              { "value": 0.75, "color": "green" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["last"], "fields": "", "values": false },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "levelhead_cache_hit_ratio",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Rate Limit Blocks (5m)",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": {
+        "reduceOptions": { "calcs": ["last"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "increase(levelhead_rate_limit_blocks_total[5m])",
+          "legendFormat": "blocks",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Duration p95",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(levelhead_http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Miss Rate by Reason",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "req/s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(levelhead_cache_misses_by_reason_total[5m])) by (reason)",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Requests per Route",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "req/s" }, "overrides": [] },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(levelhead_http_requests_total[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" }
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+disableDeletion: false
+
+providers:
+  - name: 'levelhead'
+    folder: 'Levelhead'
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards
+      recursive: true

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'levelhead_proxy'
+    static_configs:
+      - targets:
+          - 'host.docker.internal:3000'
+        labels:
+          service: 'levelhead-proxy'

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/ApiKeyStore.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/ApiKeyStore.kt
@@ -1,0 +1,63 @@
+package club.sk1er.mods.levelhead.config
+
+import club.sk1er.mods.levelhead.Levelhead
+import com.google.gson.Gson
+import java.io.File
+import java.io.FileReader
+import java.io.FileWriter
+
+private data class PersistedApiKey(val apiKey: String?)
+
+object ApiKeyStore {
+    private val gson = Gson()
+    @Volatile
+    private var storeFile: File? = null
+
+    fun initialize(file: File) {
+        storeFile = file
+    }
+
+    fun load(): String? {
+        val file = storeFile ?: return null
+        if (!file.exists()) {
+            return null
+        }
+
+        return kotlin.runCatching {
+            FileReader(file).use { reader ->
+                gson.fromJson(reader, PersistedApiKey::class.java)?.apiKey?.trim().orEmpty()
+            }
+        }.onFailure { throwable ->
+            Levelhead.logger.warn("Failed to read persisted API key store", throwable)
+        }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    fun save(apiKey: String) {
+        val file = storeFile ?: return
+        val sanitized = apiKey.trim()
+        if (sanitized.isEmpty()) {
+            clear()
+            return
+        }
+
+        kotlin.runCatching {
+            file.parentFile?.takeIf { !it.exists() }?.mkdirs()
+            FileWriter(file).use { writer ->
+                gson.toJson(PersistedApiKey(sanitized), writer)
+            }
+        }.onFailure { throwable ->
+            Levelhead.logger.error("Failed to persist API key", throwable)
+        }
+    }
+
+    fun clear() {
+        val file = storeFile ?: return
+        if (!file.exists()) {
+            return
+        }
+
+        if (!file.delete()) {
+            Levelhead.logger.warn("Failed to delete persisted API key store at {}", file.absolutePath)
+        }
+    }
+}

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -3,6 +3,7 @@ package club.sk1er.mods.levelhead.config
 import club.sk1er.mods.levelhead.bedwars.BedwarsFetcher
 import net.minecraftforge.common.config.Configuration
 import java.io.File
+import java.time.Duration
 import java.util.UUID
 
 object LevelheadConfig {
@@ -12,11 +13,18 @@ object LevelheadConfig {
     private const val PROPERTY_PROXY_BASE_URL = "proxyBaseUrl"
     private const val PROPERTY_PROXY_AUTH_TOKEN = "proxyAuthToken"
     private const val PROPERTY_INSTALL_ID = "installId"
+    private const val PROPERTY_STAR_CACHE_TTL_MINUTES = "starCacheTtlMinutes"
     private const val API_KEY_COMMENT = "Hypixel API key used for BedWars integrations"
     private const val PROXY_ENABLED_COMMENT = "Enable fetching BedWars stats from a proxy backend"
     private const val PROXY_BASE_URL_COMMENT = "Base URL for the proxy backend (e.g. https://example.com)"
     private const val PROXY_AUTH_TOKEN_COMMENT = "Bearer token used to authenticate with the proxy backend"
     private const val INSTALL_ID_COMMENT = "Unique identifier for this BedWars Levelhead installation"
+    private const val STAR_CACHE_TTL_COMMENT =
+        "Duration (in minutes) to cache BedWars stars locally before revalidating with the proxy/Hypixel"
+
+    const val MIN_STAR_CACHE_TTL_MINUTES = 5
+    const val MAX_STAR_CACHE_TTL_MINUTES = 180
+    const val DEFAULT_STAR_CACHE_TTL_MINUTES = 45
 
     private lateinit var configuration: Configuration
 
@@ -35,16 +43,34 @@ object LevelheadConfig {
     var installId: String = ""
         private set
 
+    var starCacheTtlMinutes: Int = DEFAULT_STAR_CACHE_TTL_MINUTES
+        private set
+
+    val starCacheTtl: Duration
+        get() = Duration.ofMinutes(starCacheTtlMinutes.toLong())
+
     fun initialize(configFile: File) {
         configFile.parentFile?.takeIf { !it.exists() }?.mkdirs()
         configuration = Configuration(configFile)
+        val keyStoreDirectory = configFile.parentFile ?: configFile
+        val keyStoreFile = File(keyStoreDirectory, "bedwars-levelhead-apikey.json")
+        ApiKeyStore.initialize(keyStoreFile)
         load()
     }
 
     private fun load() {
         configuration.load()
         val apiKeyProperty = configuration.get(CATEGORY_GENERAL, PROPERTY_API_KEY, "", API_KEY_COMMENT)
-        apiKey = apiKeyProperty.string.trim()
+        val persistedKey = ApiKeyStore.load()
+        val propertyKey = apiKeyProperty.string.trim()
+        apiKey = when {
+            !persistedKey.isNullOrBlank() -> persistedKey
+            propertyKey.isNotEmpty() -> propertyKey
+            else -> ""
+        }
+        if (!persistedKey.isNullOrBlank() && persistedKey != propertyKey) {
+            apiKeyProperty.set(persistedKey)
+        }
 
         val proxyEnabledProperty = configuration.get(CATEGORY_GENERAL, PROPERTY_PROXY_ENABLED, false, PROXY_ENABLED_COMMENT)
         proxyEnabled = proxyEnabledProperty.boolean
@@ -64,13 +90,33 @@ object LevelheadConfig {
         } else {
             installId = existingInstallId
         }
+
+        val starCacheTtlProperty = configuration.get(
+            CATEGORY_GENERAL,
+            PROPERTY_STAR_CACHE_TTL_MINUTES,
+            DEFAULT_STAR_CACHE_TTL_MINUTES,
+            STAR_CACHE_TTL_COMMENT
+        )
+        val configuredTtl = starCacheTtlProperty.int
+        val sanitizedTtl = configuredTtl.coerceIn(MIN_STAR_CACHE_TTL_MINUTES, MAX_STAR_CACHE_TTL_MINUTES)
+        starCacheTtlMinutes = sanitizedTtl
+        if (sanitizedTtl != configuredTtl) {
+            starCacheTtlProperty.set(sanitizedTtl)
+        }
         if (configuration.hasChanged()) {
             configuration.save()
         }
     }
 
     fun setApiKey(newKey: String) {
-        updateStringConfig(PROPERTY_API_KEY, API_KEY_COMMENT, newKey) { apiKey = it }
+        updateStringConfig(PROPERTY_API_KEY, API_KEY_COMMENT, newKey) { value ->
+            apiKey = value
+            if (value.isBlank()) {
+                ApiKeyStore.clear()
+            } else {
+                ApiKeyStore.save(value)
+            }
+        }
     }
 
     fun clearApiKey() {
@@ -87,6 +133,13 @@ object LevelheadConfig {
 
     fun setProxyAuthToken(authToken: String) {
         updateStringConfig(PROPERTY_PROXY_AUTH_TOKEN, PROXY_AUTH_TOKEN_COMMENT, authToken) { proxyAuthToken = it }
+    }
+
+    fun setStarCacheTtlMinutes(minutes: Int) {
+        val sanitized = minutes.coerceIn(MIN_STAR_CACHE_TTL_MINUTES, MAX_STAR_CACHE_TTL_MINUTES)
+        updateIntConfig(PROPERTY_STAR_CACHE_TTL_MINUTES, STAR_CACHE_TTL_COMMENT, sanitized) {
+            starCacheTtlMinutes = it
+        }
     }
 
     private fun updateStringConfig(
@@ -112,6 +165,20 @@ object LevelheadConfig {
     ) {
         ensureInitialized()
         val property = configuration.get(CATEGORY_GENERAL, key, false, comment)
+        property.set(value)
+        setter(value)
+        configuration.save()
+        BedwarsFetcher.resetWarnings()
+    }
+
+    private fun updateIntConfig(
+        key: String,
+        comment: String,
+        value: Int,
+        setter: (Int) -> Unit,
+    ) {
+        ensureInitialized()
+        val property = configuration.get(CATEGORY_GENERAL, key, value, comment)
         property.set(value)
         setter(value)
         configuration.save()

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/RateLimiter.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/RateLimiter.kt
@@ -2,6 +2,7 @@ package club.sk1er.mods.levelhead.core
 
 import club.sk1er.mods.levelhead.Levelhead
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.Clock
@@ -21,14 +22,15 @@ class RateLimiter constructor(
     private val interval: Duration,
     private val clock: Clock = Clock.systemDefaultZone()
 ) {
-    data class Metrics(val remaining: Int, val resetIn: Duration)
+    data class Metrics(val remaining: Int, val resetIn: Duration, val serverCooldown: Duration?)
 
     private val mutex: Mutex = Mutex()
 
     private var count: Int = 0
     private var nextInterval: Instant = Instant.ofEpochMilli(0)
     @Volatile
-    private var latestMetrics: Metrics = Metrics(capacity, Duration.ZERO)
+    private var latestMetrics: Metrics = Metrics(capacity, Duration.ZERO, null)
+    private var serverCooldownUntil: Instant? = null
 
     private val isNextInterval: Boolean
         get() = nextInterval <= clock.instant()
@@ -38,8 +40,10 @@ class RateLimiter constructor(
     fun resetState() {
         count = 0
         nextInterval = clock.instant() + interval
+        serverCooldownUntil = null
         Levelhead.displayManager.checkCacheSizes()
         Levelhead.resetRateLimiterNotification()
+        Levelhead.resetServerCooldownNotification()
         updateMetrics()
     }
 
@@ -51,7 +55,16 @@ class RateLimiter constructor(
     private fun metricsLocked(now: Instant = clock.instant()): Metrics {
         val remaining = capacity - count
         val resetIn = if (nextInterval.isBefore(now)) Duration.ZERO else Duration.between(now, nextInterval)
-        return Metrics(remaining, resetIn)
+        val cooldown = serverCooldownUntil?.let { hint ->
+            if (now.isBefore(hint)) {
+                Duration.between(now, hint)
+            } else {
+                serverCooldownUntil = null
+                null
+            }
+        }
+        val sanitizedCooldown = cooldown?.takeIf { !it.isZero && !it.isNegative }
+        return Metrics(remaining, resetIn, sanitizedCooldown)
     }
 
     private fun updateMetrics(now: Instant = clock.instant()) {
@@ -59,23 +72,74 @@ class RateLimiter constructor(
     }
 
     suspend fun consume() = mutex.withLock {
-        if (isNextInterval) resetState()
-
-        if (isAtCapacity) {
+        loop@ while (true) {
             val now = clock.instant()
-            val metrics = metricsLocked(now)
-            val safeWait = metrics.resetIn
-            Levelhead.logger.info(
-                "Reached Levelhead API throttle (150 requests per 5 minutes). Waiting ${safeWait.toMinutes()} minutes (${safeWait.seconds} seconds) before retrying."
-            )
-            Levelhead.onRateLimiterBlocked(metrics)
-            delayUntilNextInterval()
-            resetState()
-        }
 
-        count++
-        updateMetrics()
+            val cooldownHint = serverCooldownUntil
+            if (cooldownHint != null) {
+                if (now.isBefore(cooldownHint)) {
+                    val wait = Duration.between(now, cooldownHint)
+                    Levelhead.logger.info(
+                        "Respecting server Retry-After hint for ${wait.seconds} seconds before issuing more BedWars requests."
+                    )
+                    delay(wait.toKotlinDuration())
+                    serverCooldownUntil = null
+                    resetState()
+                    continue@loop
+                } else {
+                    serverCooldownUntil = null
+                }
+            }
+
+            if (isNextInterval) {
+                resetState()
+                continue@loop
+            }
+
+            if (isAtCapacity) {
+                val metrics = metricsLocked(now)
+                val safeWait = metrics.resetIn
+                Levelhead.logger.info(
+                    "Reached Levelhead API throttle (150 requests per 5 minutes). Waiting ${safeWait.toMinutes()} minutes (${safeWait.seconds} seconds) before retrying."
+                )
+                Levelhead.onRateLimiterBlocked(metrics)
+                delayUntilNextInterval()
+                resetState()
+                continue@loop
+            }
+
+            count++
+            updateMetrics(now)
+            return@withLock
+        }
     }
 
     fun metricsSnapshot(): Metrics = latestMetrics
+
+    fun registerServerCooldown(duration: Duration) {
+        if (duration.isZero || duration.isNegative) return
+        val sanitized = duration
+        Levelhead.scope.launch {
+            var applied = false
+            mutex.withLock {
+                val now = clock.instant()
+                val target = now + sanitized
+                val currentHint = serverCooldownUntil
+                if (currentHint == null || currentHint.isBefore(target)) {
+                    serverCooldownUntil = target
+                    if (nextInterval.isBefore(target)) {
+                        nextInterval = target
+                    }
+                    updateMetrics(now)
+                    applied = true
+                }
+            }
+            if (applied) {
+                Levelhead.logger.info(
+                    "Server requested cooldown for ${sanitized.seconds} seconds via Retry-After."
+                )
+                Levelhead.onServerRetryAfter(sanitized)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- persist user-provided API keys, make the star cache TTL configurable, and surface cache miss reasons in the client status output
- teach the mod and backend to honor Retry-After hints while adding an admin cache purge endpoint for the proxy
- ship a ready-to-run Prometheus + Grafana stack to visualize cache hit ratio, rate-limit blocks, and latency metrics

## Testing
- ./gradlew build
- (cd backend && npm run build)


------
https://chatgpt.com/codex/tasks/task_b_68f3f45f337c832db5e0b0885f7ed5c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Monitoring dashboard (Prometheus + Grafana) for proxy performance insights
  * Star cache TTL configuration command to adjust cache lifetime
  * Server cooldown notifications when rate limits are encountered
  * API key persistence to disk

* **Improvements**
  * Enhanced rate limiting with Retry-After header support
  * Extended status reporting with cache metrics and server cooldown timing
  * Improved error response header handling
  * Admin cache purge endpoint for cache management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->