### PR TITLE
Add Levelhead enable/disable controls with GUI toggle

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -164,17 +164,12 @@ class LevelheadCommand : Command("levelhead") {
         val changed = Levelhead.displayManager.setEnabled(enabled)
         val stateText = if (enabled) "enabled" else "disabled"
         val color = if (enabled) ChatColor.GREEN else ChatColor.RED
-        if (changed) {
-            EssentialAPI.getMinecraftUtil().sendMessage(
-                "${ChatColor.AQUA}[Levelhead]",
-                "${color}BedWars Levelhead ${ChatColor.YELLOW}has been ${color}$stateText${ChatColor.YELLOW}."
-            )
+        val message = if (changed) {
+            "${color}BedWars Levelhead ${ChatColor.YELLOW}has been ${color}$stateText${ChatColor.YELLOW}."
         } else {
-            EssentialAPI.getMinecraftUtil().sendMessage(
-                "${ChatColor.AQUA}[Levelhead]",
-                "${ChatColor.YELLOW}BedWars Levelhead is already ${color}$stateText${ChatColor.YELLOW}."
-            )
+            "${ChatColor.YELLOW}BedWars Levelhead is already ${color}$stateText${ChatColor.YELLOW}."
         }
+        EssentialAPI.getMinecraftUtil().sendMessage("${ChatColor.AQUA}[Levelhead]", message)
     }
 
     private fun formatAge(ageMillis: Long?): String {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
@@ -126,6 +126,7 @@ class DisplayManager(val file: File) {
 
     @OptIn(ExperimentalStdlibApi::class)
     fun playerJoin(player: EntityPlayer) {
+        if (!config.enabled) return
         if (player.isNPC) return
         if (!BedwarsModeDetector.shouldRequestData()) return
         val displays = aboveHead.filter { it.config.enabled }
@@ -174,6 +175,7 @@ class DisplayManager(val file: File) {
 
     @OptIn(ExperimentalStdlibApi::class)
     fun requestAllDisplays() {
+        if (!config.enabled) return
         if (!BedwarsModeDetector.shouldRequestData()) return
         val displays = aboveHead.filter { it.config.enabled }
         if (displays.isEmpty()) return

--- a/src/main/kotlin/club/sk1er/mods/levelhead/gui/LevelheadToggleScreen.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/gui/LevelheadToggleScreen.kt
@@ -34,23 +34,23 @@ class LevelheadToggleScreen : GuiScreen() {
         }
     }
 
-    override fun keyTyped(typedChar: Char, keyCode: Int) {
-        if (keyCode == Keyboard.KEY_ESCAPE) {
-            mc.displayGuiScreen(null)
-            return
-        }
-        super.keyTyped(typedChar, keyCode)
-    }
-
     override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
         drawDefaultBackground()
         val title = "BedWars Levelhead"
         drawCenteredString(fontRendererObj, title, width / 2, height / 2 - 60, 0xFFFFFF)
-        val enabled = Levelhead.displayManager.config.enabled
-        val statusColor = if (enabled) 0x55FF55 else 0xFF5555
-        val statusText = if (enabled) "Enabled" else "Disabled"
+        val (statusText, statusColor) = if (Levelhead.displayManager.config.enabled) {
+            "Enabled" to ENABLED_COLOR
+        } else {
+            "Disabled" to DISABLED_COLOR
+        }
         drawCenteredString(fontRendererObj, "Status: $statusText", width / 2, height / 2 - 40, statusColor)
-        drawCenteredString(fontRendererObj, "Click the button below to toggle the display.", width / 2, height / 2 - 24, 0xCCCCCC)
+        drawCenteredString(
+            fontRendererObj,
+            "Click the button below to toggle the display.",
+            width / 2,
+            height / 2 - 24,
+            0xCCCCCC
+        )
         super.drawScreen(mouseX, mouseY, partialTicks)
     }
 
@@ -60,5 +60,10 @@ class LevelheadToggleScreen : GuiScreen() {
         } else {
             "Enable BedWars Levelhead"
         }
+    }
+
+    private companion object {
+        private const val ENABLED_COLOR = 0x55FF55
+        private const val DISABLED_COLOR = 0xFF5555
     }
 }


### PR DESCRIPTION
## Summary
- add Levelhead command subcommands to enable, disable, toggle, and open a simple toggle GUI
- persist the enabled state through DisplayManager and refresh caches when the state changes
- implement a lightweight toggle screen that shows current status and lets players switch Levelhead on or off

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_b_68f67cdee08c832daec2e66b240be96f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/levelhead enable`, `/levelhead disable`, and `/levelhead toggle` commands to control display.
  * Added `/levelhead gui` command to open display settings screen.
  * New GUI screen with status display and toggle functionality for managing Levelhead display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->