### PR TITLE
Fix Levelhead GUI command to open toggle screen reliably

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -94,7 +94,10 @@ class LevelheadCommand : Command("levelhead") {
 
     @SubCommand(value = "gui")
     fun handleGui() {
-        UMinecraft.getMinecraft().displayGuiScreen(LevelheadToggleScreen())
+        val minecraft = UMinecraft.getMinecraft()
+        minecraft.addScheduledTask {
+            minecraft.displayGuiScreen(LevelheadToggleScreen())
+        }
     }
 
     @SubCommand(value = "status")


### PR DESCRIPTION
## Summary
- schedule the GUI opening on Minecraft's main thread so `/levelhead gui` reliably displays the toggle screen

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68f69882ea58832d924a8129954d673f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and responsiveness of the Levelhead settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->