### PR TITLE
Fix mixin name resolution in release builds

### DIFF
--- a/src/main/kotlin/me/beeny/bedwarslevelhead/mixins/EntityRendererMixin.kt
+++ b/src/main/kotlin/me/beeny/bedwarslevelhead/mixins/EntityRendererMixin.kt
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable
 class EntityRendererMixin {
 
     @ModifyVariable(
-        method = ["renderName"],
+        method = ["renderName", "func_177067_a"],
         at = At("STORE"),
         ordinal = 0
     )


### PR DESCRIPTION
## Summary
- add the obfuscated method name for `RendererLivingEntity.renderName` to the entity name tag mixin so it can apply in production

## Testing
- `./gradlew build --console=plain --no-daemon` *(fails: requires a Java 8 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_69066c602bb8832db4cc9f4883bf67fe