### PR TITLE
Enable public backend by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BedWars Levelhead is a lightweight reimagining of the classic **Levelhead** mod 
 1. Install the mod just like any other Forge/LiteLoader mod compatible with your client.
 2. Join Hypixel (`mc.hypixel.net`).
 3. Run `/levelhead` to view your current configuration and available subcommands.
-4. If you use the public proxy, no Hypixel API key is required. To run fully offline or during backend outages, request an API key from Hypixel (`/api new`) and configure it with `/levelhead apikey <key>`.
+4. The public Levelhead backend is enabled by default, so you can play without configuring anything. If you prefer to query Hypixel directly (or the backend is unavailable), request an API key from Hypixel (`/api new`) and configure it with `/levelhead apikey <key>`.
 
 ---
 

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -409,7 +409,7 @@ object Levelhead {
         val starCacheSnapshot = starCacheMetrics.snapshot()
         return StatusSnapshot(
             proxyEnabled = LevelheadConfig.proxyEnabled,
-            proxyConfigured = LevelheadConfig.proxyEnabled && LevelheadConfig.proxyBaseUrl.isNotBlank() && LevelheadConfig.proxyAuthToken.isNotBlank(),
+            proxyConfigured = LevelheadConfig.proxyEnabled && LevelheadConfig.proxyBaseUrl.isNotBlank(),
             cacheSize = starCache.size,
             lastAttemptAgeMillis = attemptAge,
             lastSuccessAgeMillis = successAge,

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -167,8 +167,9 @@ class LevelheadCommand : CommandBase() {
         val snapshot = Levelhead.statusSnapshot()
         val proxyStatus = when {
             !snapshot.proxyEnabled -> "disabled"
-            snapshot.proxyConfigured -> "configured"
-            else -> "missing config"
+            LevelheadConfig.proxyBaseUrl.isBlank() -> "missing URL"
+            LevelheadConfig.proxyAuthToken.isBlank() -> "public backend"
+            else -> "private backend"
         }
         val lastAttempt = formatAge(snapshot.lastAttemptAgeMillis)
         val lastSuccess = formatAge(snapshot.lastSuccessAgeMillis)
@@ -219,8 +220,9 @@ class LevelheadCommand : CommandBase() {
         if (args.isEmpty()) {
             val status = when {
                 !LevelheadConfig.proxyEnabled -> "disabled"
-                LevelheadConfig.proxyBaseUrl.isBlank() || LevelheadConfig.proxyAuthToken.isBlank() -> "misconfigured"
-                else -> "configured"
+                LevelheadConfig.proxyBaseUrl.isBlank() -> "missing URL"
+                LevelheadConfig.proxyAuthToken.isBlank() -> "public backend"
+                else -> "private backend"
             }
             sendMessage("§eProxy is currently §6$status§e.")
             sendProxyHelp()
@@ -481,11 +483,12 @@ class LevelheadCommand : CommandBase() {
     }
 
     private fun sendProxyHelp() {
-        val baseUrl = LevelheadConfig.proxyBaseUrl.ifBlank { "not set" }
-        val tokenState = if (LevelheadConfig.proxyAuthToken.isBlank()) "not set" else "configured"
+        val baseUrl = LevelheadConfig.proxyBaseUrl.ifBlank { LevelheadConfig.DEFAULT_PROXY_BASE_URL }
+        val tokenState = if (LevelheadConfig.proxyAuthToken.isBlank()) "not set (public mode)" else "configured"
         val enabledState = formatToggle(LevelheadConfig.proxyEnabled)
-        sendMessage("§eOptions: enable/disable toggle usage ($enabledState), url to set the backend (§6$baseUrl§e), token to update auth (§6$tokenState§e).")
-        sendMessage("§eTry: §6/levelhead proxy enable§e, §6/levelhead proxy url https://example.com§e, §6/levelhead proxy token <token>§e.")
+        sendMessage("§eDefault backend: §6${LevelheadConfig.DEFAULT_PROXY_BASE_URL}§e (public, no token required).")
+        sendMessage("§eOptions: enable/disable toggle usage ($enabledState), URL override (§6$baseUrl§e), token for private/admin routes (§6$tokenState§e).")
+        sendMessage("§eTry: §6/levelhead proxy disable§e to fall back to Hypixel, §6/levelhead proxy url https://example.com§e to self-host, or §6/levelhead proxy token <token>§e for admin access.")
     }
 
     private fun sendAdminHelp() {


### PR DESCRIPTION
## Summary
- default to the hosted Levelhead backend in configuration so fresh installs immediately use the proxy
- update in-game proxy status/help messaging and README to reflect the public backend option

## Testing
- `./gradlew build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm'] was not found; missing plugin version in build script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691085d877fc832d857e349ae06210fc)