### PR TITLE
Ensure archives are remapped and lazy Minecraft access

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ loom {
     mixin {
         defaultRefmapName.set("mixins.levelhead.refmap.json")
     }
+    remapArchives.set(true)
     launchConfigs {
         getByName("client") {
             property("mixin.debug.verbose", "true")

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -72,7 +72,8 @@ object Levelhead {
     val gson = Gson()
     val jsonParser = JsonParser()
 
-    val displayManager: DisplayManager = DisplayManager(File(File(Minecraft.getMinecraft().mcDataDir, "config"), "levelhead.json"))
+    private val configFile by lazy { File(File(minecraft.mcDataDir, "config"), "levelhead.json") }
+    val displayManager: DisplayManager by lazy { DisplayManager(configFile) }
     private val modJob: Job = SupervisorJob()
     val scope: CoroutineScope = CoroutineScope(modJob + Dispatchers.IO)
     private val worldScopeLock = Any()


### PR DESCRIPTION
## Summary
- enable loom archive remapping so production jars use the correct obfuscation mappings
- lazily create the display manager using the Minecraft instance-derived config file

## Testing
- ./gradlew build --console plain --no-daemon *(fails: could not download com.mojang:minecraft:1.8.9; missing cache file)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237444333883248b6141765fd40298)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved archive processing
  * Optimized display management initialization timing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->