### PR TITLE
Embed OneConfig dependency to include Kotlin adapter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     modCompileOnly(oneconfig)
     modImplementation(oneconfig)
 
+    embed(oneconfig)
+
     modCompileOnly(universalcraft)
     modImplementation(universalcraft)
 


### PR DESCRIPTION
## Summary
- embed the OneConfig dependency so the Kotlin language adapter is packaged into the mod JAR
- keep existing embedded Kotlin libraries alongside the adapter

## Testing
- ./gradlew jar --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247e9f6e9c8324a9bb73f92b3803ac)