### PR TITLE
Ensure shadow jar is remapped

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.fabricmc.loom.task.RemapJarTask
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.jvm.tasks.Jar
 
@@ -65,6 +67,14 @@ dependencies {
     compileOnly("org.spongepowered:mixin:0.8.5-SNAPSHOT")
 }
 
+val manifestAttributes = mapOf(
+    "ModSide" to "CLIENT",
+    "FMLCorePluginContainsFMLMod" to "Yes, yes it does",
+    "TweakClass" to "cc.polyfrost.oneconfig.loader.stage0.LaunchWrapperTweaker",
+    "TweakOrder" to "0",
+    "MixinConfigs" to "mixins.levelhead.json"
+)
+
 tasks.compileKotlin {
     kotlinOptions {
         freeCompilerArgs += listOf("-Xno-param-assertions", "-Xjvm-default=all-compatibility")
@@ -76,15 +86,17 @@ tasks.withType<Jar> {
 }
 
 tasks.jar {
-    from(embed.files.map { zipTree(it) })
+    manifest.attributes(manifestAttributes)
+}
 
-    manifest.attributes(
-        mapOf(
-            "ModSide" to "CLIENT",
-            "FMLCorePluginContainsFMLMod" to "Yes, yes it does",
-            "TweakClass" to "cc.polyfrost.oneconfig.loader.stage0.LaunchWrapperTweaker",
-            "TweakOrder" to "0",
-            "MixinConfigs" to "mixins.levelhead.json"
-        )
-    )
+tasks.named<ShadowJar>("shadowJar") {
+    configurations = listOf(embed)
+    archiveClassifier.set("dev")
+    manifest.attributes(manifestAttributes)
+}
+
+tasks.named<RemapJarTask>("remapJar") {
+    input.set(tasks.named<ShadowJar>("shadowJar").flatMap { it.archiveFile })
+    dependsOn(tasks.named("shadowJar"))
+    archiveClassifier.set("")
 }


### PR DESCRIPTION
## Summary
- configure the shadow jar to bundle embedded dependencies with the correct manifest
- remap the final artifact from the shadow output so shaded libraries are obfuscated

## Testing
- ./gradlew build --no-daemon --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c4a752b083248fe634427a0b3b1f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process configuration with improved artifact packaging and manifest handling to streamline the compilation pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->