### PR TITLE
Remove OneConfig language adapter requirement

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -60,8 +60,19 @@ import kotlin.random.Random
     modid = Levelhead.MODID,
     name = "BedWars Levelhead",
     version = Levelhead.VERSION,
-    modLanguageAdapter = "cc.polyfrost.oneconfig.utils.KotlinAdapter",
 )
+class LevelheadMod {
+    @Mod.EventHandler
+    fun preInit(event: FMLPreInitializationEvent) {
+        Levelhead.preInit(event)
+    }
+
+    @Mod.EventHandler
+    fun postInit(event: FMLPostInitializationEvent) {
+        Levelhead.postInit(event)
+    }
+}
+
 object Levelhead {
     val logger: Logger = LogManager.getLogger()
     val okHttpClient: OkHttpClient = OkHttpClient.Builder()
@@ -194,12 +205,10 @@ object Levelhead {
     val chromaColor: Color
         get() = Color(ChromaColor)
 
-    @Mod.EventHandler
     fun preInit(@Suppress("UNUSED_PARAMETER") event: FMLPreInitializationEvent) {
         LevelheadConfig
     }
 
-    @Mod.EventHandler
     fun postInit(@Suppress("UNUSED_PARAMETER") event: FMLPostInitializationEvent) {
         MinecraftForge.EVENT_BUS.register(AboveHeadRender)
         MinecraftForge.EVENT_BUS.register(BedwarsModeDetector)


### PR DESCRIPTION
## Summary
- create a dedicated Forge mod entrypoint class so the mod no longer depends on the OneConfig Kotlin language adapter
- delegate mod lifecycle callbacks to the existing Levelhead logic without using a custom adapter

## Testing
- ./gradlew build --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256b7a64508324b36a807c451de19c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured mod initialization architecture for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->