### PR TITLE
Use OneColor for OneConfig color fields

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -7,9 +7,9 @@ import cc.polyfrost.oneconfig.config.annotations.Header
 import cc.polyfrost.oneconfig.config.annotations.Slider
 import cc.polyfrost.oneconfig.config.annotations.Switch
 import cc.polyfrost.oneconfig.config.annotations.Text
+import cc.polyfrost.oneconfig.config.core.OneColor
 import cc.polyfrost.oneconfig.config.data.Mod
 import cc.polyfrost.oneconfig.config.data.ModType
-import java.awt.Color as AwtColor
 import java.time.Duration
 import java.util.Locale
 import java.util.UUID
@@ -52,13 +52,13 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
     var headerString: String = "BedWars Star"
 
     @Color(name = "Header Color")
-    var headerColor: AwtColor = AwtColor(85, 255, 255)
+    var headerColor: OneColor = OneColor(85, 255, 255)
 
     @Text(name = "Footer Template", description = "Supports %star%, %fkdr%, %ws%")
     var footerTemplate: String = "%star%"
 
     @Color(name = "Footer Color")
-    var footerColor: AwtColor = AwtColor(255, 255, 85)
+    var footerColor: OneColor = OneColor(255, 255, 85)
 
     @Switch(name = "Show Self")
     var showSelf: Boolean = true


### PR DESCRIPTION
## Summary
- replace OneConfig color-annotated fields to use OneColor instead of java.awt.Color to satisfy validation

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d79b66f883248344640e2ae25945)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to color configuration handling with no impact on user experience or application behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->