### PR TITLE
Fix admin command parameter parsing

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -302,15 +302,18 @@ class LevelheadCommand {
     }
 
     @SubCommand
-    fun admin(vararg args: String) {
-        if (args.isEmpty()) {
+    fun admin(@Greedy args: String) {
+        val parsedArgs = args.split(" ")
+            .mapNotNull { it.takeIf(String::isNotBlank) }
+
+        if (parsedArgs.isEmpty()) {
             sendAdminHelp()
             return
         }
-        when (args[0].lowercase(Locale.ROOT)) {
-            "purgecache" -> handleAdminPurgeCache(args.drop(1).toTypedArray())
+        when (parsedArgs[0].lowercase(Locale.ROOT)) {
+            "purgecache" -> handleAdminPurgeCache(parsedArgs.drop(1).toTypedArray())
             else -> {
-                sendMessage("${ChatColor.RED}Unknown admin action '${args[0]}'.")
+                sendMessage("${ChatColor.RED}Unknown admin action '${parsedArgs[0]}'.")
                 sendAdminHelp()
             }
         }


### PR DESCRIPTION
## Summary
- replace the admin command's vararg parameter with a greedy string compatible with OneConfig parsing
- preserve command behavior by splitting the captured input into tokens before dispatch

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69275a14d8308324b26401925aa8b12f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved command parsing logic for enhanced input handling and consistency in error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->