### PR TITLE
Improve timeout resilience for IPv4 requests

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
@@ -208,8 +208,6 @@ class DisplayManager(val file: File) {
                 }
             }
             ?.flatten()
-            ?.chunked(20) { reqList ->
-                Levelhead.fetchBatch(reqList)
-            }
+            ?.let { Levelhead.fetchBatch(it) }
     }
 }


### PR DESCRIPTION
## Summary
- increase OkHttp timeouts while keeping IPv4-only DNS resolution
- retry proxy and Hypixel BedWars fetches when timeouts occur before failing

## Testing
- ./gradlew build -x test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276dc7157083249b9bfa9a515f11ab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network reliability with IPv4-only DNS resolution
  * Enhanced timeout and error handling with automatic retry logic
  * Better detection and recovery from network failures

* **Performance**
  * Optimized batch processing for improved efficiency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->