### PR TITLE
Expose enabled config field for Levelhead access

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -23,6 +23,7 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
     const val DEFAULT_STAR_CACHE_TTL_MINUTES = 45
     @Header(text = "General")
     @Switch(name = "Enabled", description = "Toggle the BedWars Levelhead overlay")
+    @JvmField
     var enabled: Boolean = true
 
     @Text(name = "Hypixel API Key", placeholder = "Run /api new", secure = true)


### PR DESCRIPTION
## Summary
- mark `LevelheadConfig.enabled` as a JVM field so Levelhead can access it directly during initialization

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297b689d348324938958068bfc92bd)