### PR TITLE
Remove static exposure for LevelheadConfig enabled flag

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -23,7 +23,6 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
     const val DEFAULT_STAR_CACHE_TTL_MINUTES = 45
     @Header(text = "General")
     @Switch(name = "Enabled", description = "Toggle the BedWars Levelhead overlay")
-    @JvmField
     var enabled: Boolean = true
 
     @Text(name = "Hypixel API Key", placeholder = "Run /api new", secure = true)


### PR DESCRIPTION
## Summary
- remove @JvmField from the enabled config flag so it remains an instance-backed property

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297faf911483248dea8625d08f5547)