### PR TITLE
Expose enabled as public static field

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -23,6 +23,7 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
     const val DEFAULT_STAR_CACHE_TTL_MINUTES = 45
     @Header(text = "General")
     @Switch(name = "Enabled", description = "Toggle the BedWars Levelhead overlay")
+    @JvmField
     var enabled: Boolean = true
 
     @Text(name = "Hypixel API Key", placeholder = "Run /api new", secure = true)


### PR DESCRIPTION
## Summary
- annotate LevelheadConfig.enabled with @JvmField to expose it as a public static field for Java callers

## Testing
- ./gradlew build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692981c3caf48324804da46aff95f310)