### PR TITLE
Make enabled config flag non-static

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -23,7 +23,6 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
     const val DEFAULT_STAR_CACHE_TTL_MINUTES = 45
     @Header(text = "General")
     @Switch(name = "Enabled", description = "Toggle the BedWars Levelhead overlay")
-    @JvmField
     var enabled: Boolean = true
 
     @Text(name = "Hypixel API Key", placeholder = "Run /api new", secure = true)


### PR DESCRIPTION
## Summary
- remove static exposure on the `enabled` config flag to align bytecode with instance access

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ace5d8b1c832494381c6b68df0e2b)