### PR TITLE
Make stats charts resizable and safeguard query logging

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -167,7 +167,6 @@
       "integrity": "sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1302,7 +1301,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -1940,7 +1938,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/routes/playerPublic.ts
+++ b/backend/src/routes/playerPublic.ts
@@ -15,6 +15,19 @@ function parseIfModifiedSince(value: string | undefined): number | undefined {
 
 const router = Router();
 
+async function recordQuerySafely(payload: Parameters<typeof recordPlayerQuery>[0]): Promise<void> {
+  try {
+    await recordPlayerQuery(payload);
+  } catch (error) {
+    console.error('Failed to record public player query', {
+      error,
+      identifier: payload.identifier,
+      lookupType: payload.lookupType,
+      responseStatus: payload.responseStatus,
+    });
+  }
+}
+
 function extractBedwarsExperience(payload: ResolvedPlayer['payload']): number | null {
   const bedwars = payload.data?.bedwars ?? payload.bedwars;
   if (!bedwars || typeof bedwars !== 'object') {
@@ -62,7 +75,7 @@ router.get('/:identifier', enforcePublicRateLimit, async (req, res, next) => {
     const notModified = req.fresh;
     const responseStatus = notModified ? 304 : 200;
 
-    await recordPlayerQuery({
+    await recordQuerySafely({
       identifier,
       normalizedIdentifier: resolved.lookupValue,
       lookupType: resolved.lookupType,


### PR DESCRIPTION
## Summary
- add a chart height control to the stats dashboard and render charts in resizable containers
- persist preferred chart height and remove aspect ratio constraints for better fit across sizes
- guard player query history writes so lookup responses are returned even if logging fails

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5f50fb488324bf800ff668fed93d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience—query recording failures no longer impact API responses.

* **New Features**
  * Enhanced analytics dashboard with multiple charts: cache performance, latency distribution, status breakdown.
  * New computed metrics: cache hit rate, success rate, latency percentiles.
  * Customizable chart height with persistent user preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->