### PR TITLE
Increase cache TTL to 72 hours

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -114,10 +114,10 @@ export const HYPIXEL_API_BASE_URL = process.env.HYPIXEL_API_BASE_URL ?? 'https:/
 export const CLOUD_FLARE_TUNNEL = process.env.CLOUDFLARE_TUNNEL ?? '';
 
 const HOURS = 60 * 60 * 1000;
-const defaultCacheTtl = 24 * HOURS;
+const defaultCacheTtl = 72 * HOURS;
 const rawCacheTtl = parseIntEnv('CACHE_TTL_MS', defaultCacheTtl);
 const minimumCacheTtl = 1 * HOURS;
-const maximumCacheTtl = 24 * HOURS;
+const maximumCacheTtl = 72 * HOURS;
 
 export const CACHE_TTL_MS = Math.min(Math.max(rawCacheTtl, minimumCacheTtl), maximumCacheTtl);
 


### PR DESCRIPTION
## Summary
- raise the default backend cache TTL to 72 hours and allow overrides up to that limit

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c3db1520483249f81b59439139436)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended cache retention periods to enhance application performance and reduce server load for frequently accessed data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->