### PR TITLE
Fix lobby network requests and add config migration

### DIFF
--- a/backend/src/services/history.ts
+++ b/backend/src/services/history.ts
@@ -63,6 +63,7 @@ export interface TopPlayer {
 }
 
 const DEFAULT_PLAYER_QUERIES_LIMIT = 200;
+const MAX_ALLOWED_LIMIT = 10000;
 
 const initialization = (async () => {
   try {
@@ -250,9 +251,12 @@ export async function getPlayerQueriesWithFilters(params: {
     1,
   );
 
+  // If time filters are present but no limit specified, use MAX_ALLOWED_LIMIT
+  // to show all data within the time range. Otherwise, use default limit.
+  const hasTimeFilters = params.startDate !== undefined || params.endDate !== undefined;
   const requestedLimit = params.limit !== undefined && params.limit > 0
-    ? params.limit
-    : DEFAULT_PLAYER_QUERIES_LIMIT;
+    ? Math.min(params.limit, MAX_ALLOWED_LIMIT)
+    : (hasTimeFilters ? MAX_ALLOWED_LIMIT : DEFAULT_PLAYER_QUERIES_LIMIT);
   const limitClause = `LIMIT $${dateParams.length + 1}`;
   const queryParams = [...dateParams, requestedLimit];
 

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -249,7 +249,7 @@ object Levelhead {
 
     fun fetchBatch(requests: List<LevelheadRequest>): Job {
         return worldScope.launch {
-            if (!BedwarsModeDetector.shouldRequestData()) return@launch
+            if (!Levelhead.isOnHypixel()) return@launch
             if (requests.isEmpty()) return@launch
 
             val now = System.currentTimeMillis()
@@ -277,6 +277,7 @@ object Levelhead {
                 }
 
             if (pending.isEmpty()) return@launch
+            if (!BedwarsModeDetector.isInBedwarsMatch()) return@launch
 
             val remaining = pending.toMutableList()
 


### PR DESCRIPTION
## Changes

### 1. Restrict Network Requests to Matches Only
- **Problem**: The mod was making network requests for 120+ players in BedWars lobbies, causing unnecessary API spam
- **Solution**: Modified `fetchBatch` in `Levelhead.kt` to only make network requests during actual matches (`isInBedwarsMatch()`), not in lobbies
- **Behavior**: 
  - Cache lookups still work in lobbies (shows cached stars from previous games)
  - Network requests are blocked in lobbies (prevents API spam)
  - Network requests only happen during actual matches

### 2. Config Migration for Backward Compatibility
- **Problem**: Changing `@SerializedName` from `"enabled"` to `"bedwarsEnabled"` would break existing config files
- **Solution**: Added `migrateLegacyConfig()` function that automatically migrates old config files
- **Behavior**: 
  - Detects old `"enabled"` key in JSON
  - Migrates it to `"bedwarsEnabled"`
  - Preserves user settings when updating the mod

### 3. History Query Limit Enforcement
- **Problem**: No upper bound on `params.limit` in history queries could allow abuse
- **Solution**: Added `Math.min(params.limit, MAX_ALLOWED_LIMIT)` to clamp the limit
- **Behavior**: Limits are now capped at `MAX_ALLOWED_LIMIT` (10,000) to prevent abuse

## Files Changed
- `src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt`
- `src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt`
- `backend/src/services/history.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic migration of legacy configurations during startup for seamless transitions.

* **Bug Fixes**
  * Enhanced server and mode detection logic to ensure accurate data processing and filtering.
  * Implemented query limits to optimize performance and prevent excessive data requests.

* **Documentation**
  * Updated API key input guidance to direct users to developer.hypixel.net for obtaining new keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->