### PR TITLE
Add scheduled health check ping workflow

### DIFF
--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -1,0 +1,14 @@
+name: Ping Healthcheck
+
+on:
+  schedule:
+    - cron: "*/13 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping health endpoint
+        run: |
+          curl -fsS https://bedwars-level-head.onrender.com/healthz


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that pings the deployed health endpoint every 13 minutes
- allow manual triggering of the health check workflow

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486574c0dc8321892fe23b3da293ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated health check monitoring to continuously verify service availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->