### PR TITLE
Fix fallback Bedwars prestige style colormap argument

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -622,7 +622,7 @@ object Levelhead {
             footerValue = footerValue.replace("%ws%", winstreakString, true)
         }
         val baseStyle = starValue?.let { BedwarsStar.styleForStar(it) }
-            ?: BedwarsStar.PrestigeStyle(display.config.footerColor, false)
+            ?: BedwarsStar.PrestigeStyle(display.config.footerColor, false, "")
         
         // Check if data is stale (> 1 hour old)
         val age = System.currentTimeMillis() - (starData?.fetchedAt ?: 0L)


### PR DESCRIPTION
## Summary
- add a default colormap value when building a fallback BedWars prestige style so compilation succeeds
- ensure the fallback still uses the configured footer color and chroma settings

## Testing
- ./gradlew test --no-daemon --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948688ea72c8321a51aa1772449e9c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated footer style configuration to align with current API standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->