### PR TITLE
fix(tab): decouple tab stats from above-head rendering

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
@@ -298,10 +298,7 @@ class DisplayManager(val file: File) {
 
             synchronized(pendingRequests) {
                 val key = RequestKey(uuid.trimmed, activeMode.typeId)
-                val existing = pendingRequests[key]
-                if (existing != null) {
-                    pendingRequests[key] = existing.copy(reason = Levelhead.RequestReason.TAB_LIST)
-                } else {
+                if (!pendingRequests.containsKey(key)) {
                     pendingRequests[key] = Levelhead.LevelheadRequest(
                         uuid = uuid.trimmed,
                         displays = emptySet(),

--- a/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/core/DisplayManager.kt
@@ -286,18 +286,30 @@ class DisplayManager(val file: File) {
      */
     @OptIn(ExperimentalStdlibApi::class)
     private fun requestTabListPlayers() {
-        if (!config.enabled) return
+        if (!LevelheadConfig.showTabStats) return
         if (!ModeManager.shouldRequestData()) return
         val activeMode = ModeManager.getActiveGameMode() ?: return
-        val display = primaryDisplay() ?: return
-        if (!display.config.enabled) return
 
         val netHandler = Minecraft.getMinecraft().thePlayer?.sendQueue ?: return
         for (info in netHandler.playerInfoMap) {
             val uuid = info.gameProfile.id ?: continue
             if (uuid.version() == 2) continue
             if (Levelhead.getCachedStats(uuid, activeMode) != null) continue
-            enqueueRequest(uuid.trimmed, display, activeMode.typeId, Levelhead.RequestReason.TAB_LIST)
+
+            synchronized(pendingRequests) {
+                val key = RequestKey(uuid.trimmed, activeMode.typeId)
+                val existing = pendingRequests[key]
+                if (existing != null) {
+                    pendingRequests[key] = existing.copy(reason = Levelhead.RequestReason.TAB_LIST)
+                } else {
+                    pendingRequests[key] = Levelhead.LevelheadRequest(
+                        uuid = uuid.trimmed,
+                        displays = emptySet(),
+                        type = activeMode.typeId,
+                        reason = Levelhead.RequestReason.TAB_LIST
+                    )
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/club/sk1er/mods/levelhead/render/TabRender.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/render/TabRender.kt
@@ -39,8 +39,7 @@ object TabRender {
      */
     @JvmStatic
     fun beginFrame(objective: ScoreObjective?) {
-        if (!Levelhead.displayManager.config.enabled ||
-            !LevelheadConfig.showTabStats ||
+        if (!LevelheadConfig.showTabStats ||
             !Levelhead.isOnHypixel()
         ) {
             frameState = null


### PR DESCRIPTION
## Summary
- stop tab rendering from depending on the main above-head display toggle
- fetch tab list stats when `showTabStats` is enabled even if nametag rendering is disabled
- queue tab-only requests without attaching above-head displays so cached stats still populate the tab list

## Testing
- ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tab-list stats are now controlled solely by the tab stats setting, independent of the main display toggle, ensuring consistent visibility on Hypixel.
  * Improved request handling for tab-list player stats to reduce redundant fetches and improve stability/responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->