### PR TITLE
🧱 Mason: Replace `as Record<string, unknown>` with `isNonArrayObject` strict type guard

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -29,3 +29,8 @@
 **Tech Debt:** Inline `as { ... }` and `as Record<string, unknown>` type assertions were repeatedly used to access properties on `req.body` and payload objects, bypassing strict type safety.
 **Learning:** Extracting type assertions into shared utilities (e.g., `extractBatchIdentifiersFromBody`) is a solid refactor, but doing so blindly can introduce DoS vulnerabilities if bounding checks (e.g., length verification) are inadvertently moved to *after* iteration/deduplication steps.
 **Prevention:** When refactoring payload extraction, always ensure that array length limits and bounding gates remain placed *before* any unbounded iteration (like deduplication loops or regex validations). Use the `isNonArrayObject` type guard directly to satisfy TypeScript without inline casting.
+
+## 2026-04-09 - Remove inline type assertions for object validation
+**Tech Debt:** Inline `as Record<string, unknown>` type assertions were repeatedly used to bypass type checking across various validation functions in Node.js backend (`submissionService.ts`, `statsCache.ts`, `hypixel.ts`, etc.).
+**Learning:** This approach undermines the strict null/array checking required for robust TypeScript, particularly since `typeof null` and `typeof []` both evaluate to `'object'`, posing logic bugs.
+**Prevention:** Always rely on a central type guard utility like `isNonArrayObject` that checks for `value !== null && typeof value === 'object' && !Array.isArray(value)` to strictly narrow unknown objects before safely accessing their properties.

--- a/backend/src/services/hypixel.ts
+++ b/backend/src/services/hypixel.ts
@@ -13,6 +13,7 @@ import {
   OUTBOUND_USER_AGENT,
 } from '../config';
 import { HttpError } from '../util/httpError';
+import { isNonArrayObject } from '../util/typeChecks';
 import { recordHypixelApiCall } from './hypixelTracker';
 import { logger } from '../util/logger';
 
@@ -192,7 +193,8 @@ export function shapePayload(response: HypixelPlayerResponse): ProxyPlayerPayloa
     throw new HttpError(502, cause, 'Hypixel returned an error response.');
   }
 
-  const bedwarsStats = response.player?.stats?.Bedwars ?? {} as Record<string, unknown>;
+  const bedwarsStatsRaw = response.player?.stats?.Bedwars;
+  const bedwarsStats = isNonArrayObject(bedwarsStatsRaw) ? bedwarsStatsRaw : {};
   const getNumericStat = (stats: Record<string, unknown>, key: string): number | undefined => {
     const val = stats[key];
     return typeof val === 'number' ? val : undefined;
@@ -211,7 +213,7 @@ export function shapePayload(response: HypixelPlayerResponse): ProxyPlayerPayloa
   const fkdr = finalDeaths <= 0 ? finalKills : finalKills / finalDeaths;
 
   // Clone to avoid hidden mutation
-  const shapedStats = { ...bedwarsStats } as Record<string, unknown>;
+  const shapedStats: Record<string, unknown> = { ...bedwarsStats };
 
   if (experience !== undefined) {
     shapedStats.bedwars_experience = experience;
@@ -287,7 +289,7 @@ function extractRetryAfterHeader(
     return undefined;
   }
 
-  const headerValue = (headers as Record<string, unknown>)['retry-after'];
+  const headerValue = isNonArrayObject(headers) ? headers['retry-after'] : undefined;
   if (!headerValue) {
     return undefined;
   }
@@ -467,9 +469,12 @@ function extractModeStats(
 }
 
 export function extractMinimalStats(response: HypixelPlayerResponse): MinimalPlayerStats {
-  const bedwarsStats = response.player?.stats?.Bedwars ?? {};
-  const duelsStats = response.player?.stats?.Duels ?? {};
-  const skywarsStats = response.player?.stats?.SkyWars ?? {};
+  const bedwarsStatsRaw = response.player?.stats?.Bedwars;
+  const duelsStatsRaw = response.player?.stats?.Duels;
+  const skywarsStatsRaw = response.player?.stats?.SkyWars;
+  const bedwarsStats = isNonArrayObject(bedwarsStatsRaw) ? bedwarsStatsRaw : {};
+  const duelsStats = isNonArrayObject(duelsStatsRaw) ? duelsStatsRaw : {};
+  const skywarsStats = isNonArrayObject(skywarsStatsRaw) ? skywarsStatsRaw : {};
 
   const bedwars = bedwarsStats as Record<string, number | undefined>;
   const skywars = skywarsStats as Record<string, number | undefined>;

--- a/backend/src/services/statsCache.ts
+++ b/backend/src/services/statsCache.ts
@@ -13,6 +13,7 @@ import {
 } from '../config';
 import { CacheEntry, CacheMetadata, CacheSource, ensureInitialized, markDbAccess, shouldReadFromDb } from './cache';
 import { DatabaseType } from './database/db';
+import { isNonArrayObject } from '../util/typeChecks';
 import { recordCacheHit, recordCacheMiss, recordCacheTierHit, recordCacheTierMiss, recordCacheSourceHit, recordCacheRefresh } from './metrics';
 import { fetchHypixelPlayer, HypixelFetchOptions, MinimalPlayerStats, extractMinimalStats } from './hypixel';
 import { getRedisClient, isRedisAvailable } from './redis';
@@ -128,8 +129,8 @@ export interface PlayerCachePayload {
 }
 
 function isPlayerCachePayload(value: unknown): value is PlayerCachePayload {
-  if (!value || typeof value !== 'object') return false;
-  const v = value as Record<string, unknown>;
+  if (!isNonArrayObject(value)) return false;
+  const v = value;
   return (
     (typeof v.payload === 'string' || (typeof v.payload === 'object' && v.payload !== null)) &&
     typeof v.expires_at === 'number' &&

--- a/backend/src/services/submissionService.ts
+++ b/backend/src/services/submissionService.ts
@@ -3,7 +3,7 @@ import { COMMUNITY_SUBMIT_SECRET } from '../config';
 import { logger } from '../util/logger';
 import { validateTimestampAndNonce, validatePlayerSubmission, matchesCriticalFields, extractBedwarsRecord } from '../util/validation';
 import { canonicalize } from '../util/signature';
-import { isValidBedwarsObject } from '../util/typeChecks';
+import { isValidBedwarsObject, isNonArrayObject } from '../util/typeChecks';
 import { MinimalPlayerStats, extractMinimalStats } from './hypixel';
 import { getPlayerStatsFromCache, setIgnMapping, setPlayerStatsBoth } from './statsCache';
 import { CacheSource } from './cache';
@@ -23,9 +23,8 @@ interface SignedData {
 }
 
 function isSignedData(data: unknown): data is SignedData {
-    if (!data || typeof data !== 'object') return false;
-    const obj = data as Record<string, unknown>;
-    return typeof obj.timestamp === 'number' && typeof obj.nonce === 'string';
+    if (!isNonArrayObject(data)) return false;
+    return typeof data.timestamp === 'number' && typeof data.nonce === 'string';
 }
 
 export class SubmissionService {
@@ -104,8 +103,8 @@ export class SubmissionService {
         return { valid: false, source: null };
       }
 
-      if (matchesCriticalFields(hypixelData, data as Record<string, unknown>)) {
-        const submittedName = (data as Record<string, unknown>).displayname;
+      if (isNonArrayObject(data) && matchesCriticalFields(hypixelData, data)) {
+        const submittedName = data.displayname;
         const actualName = result.payload.player?.displayname;
 
         if (typeof submittedName === 'string' && typeof actualName === 'string') {
@@ -169,6 +168,15 @@ export class SubmissionService {
   ): Promise<{ success: boolean; message?: string; statusCode?: number; error?: string; errorCode?: string }> {
     const normalizedUuid = uuid.trim().toLowerCase();
 
+    if (!isNonArrayObject(data)) {
+      return {
+        success: false,
+        statusCode: 422,
+        errorCode: 'VALIDATION_FAILED',
+        error: `Player data validation failed: Expected a JSON object`
+      };
+    }
+
     // Validate submission data structure
     const jsonString = JSON.stringify(data);
     const validation = validatePlayerSubmission(jsonString, data);
@@ -198,7 +206,7 @@ export class SubmissionService {
     }
 
     const cacheKey = `player:${normalizedUuid}`;
-    const submission = data as Record<string, unknown>;
+    const submission = data;
     const record = extractBedwarsRecord(submission) ?? submission;
     const existingEntry = await getPlayerStatsFromCache(cacheKey, true);
 

--- a/backend/src/util/signature.ts
+++ b/backend/src/util/signature.ts
@@ -1,3 +1,4 @@
+import { isNonArrayObject } from './typeChecks';
 /**
  * Serializes an object into a canonical JSON string format.
  * This ensures that objects with identical data but different key orders
@@ -29,8 +30,8 @@ export function canonicalize(value: unknown): string {
         return str;
     }
 
-    if (typeof value === 'object') {
-        const obj = value as Record<string, unknown>;
+    if (isNonArrayObject(value)) {
+        const obj = value;
         const keys = Object.keys(obj).sort();
         let str = '{';
         for (let i = 0; i < keys.length; i++) {

--- a/backend/src/util/validation.ts
+++ b/backend/src/util/validation.ts
@@ -134,7 +134,7 @@ function getObjectDepth(obj: unknown, currentDepth = 0): number {
     let maxDepth = currentDepth;
     for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            const value = (obj as Record<string, unknown>)[key];
+            const value = obj[key];
             const depth = getObjectDepth(value, currentDepth + 1);
             maxDepth = Math.max(maxDepth, depth);
             if (maxDepth > MAX_OBJECT_DEPTH) {


### PR DESCRIPTION
💡 What: Replaced inline `as Record<string, unknown>` assertions across multiple backend services with the strictly-typed `isNonArrayObject` utility function.
🎯 Why: Previously, objects received from `req.body` or Redis payload parsers were bypassed via `as Record<string, unknown>` allowing potential bugs where arrays or `null` were unsafely cast.
🛠️ How: Added early returns or safe fallback assignments utilizing the `isNonArrayObject` guard in `submissionService.ts`, `statsCache.ts`, `hypixel.ts`, `signature.ts`, and `validation.ts`.
✅ Verification: Ran `cd backend && pnpm run build && npx jest`. All 96 tests passed successfully with no TypeScript compilation errors.

---
*PR created automatically by Jules for task [10069270917098561793](https://jules.google.com/task/10069270917098561793) started by @beenycool*