### PR TITLE
fix(db): prevent node crash on idle postgres connection timeout

### DIFF
--- a/backend/src/services/database/db.ts
+++ b/backend/src/services/database/db.ts
@@ -254,6 +254,15 @@ if (dbType === DatabaseType.POSTGRESQL) {
 } else {
   const config = parseMssqlConfig(connectionString);
   const pool = new mssql.ConnectionPool(config);
+  // Add error listener to MSSQL pool to mirror PostgreSQL handling and
+  // prevent the Node.js process from crashing on unexpected pool errors.
+  // mssql's ConnectionPool emits 'error' for connection-level issues.
+  // Log the error so the pool can handle cleanup without bringing down the app.
+  // See PR feedback requesting parity with PostgreSQL pool handling.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (pool as any).on('error', (err: unknown) => {
+    logger.error({ err }, '[db] Unexpected error on MSSQL connection pool');
+  });
 
   db = new Kysely<Database>({
     dialect: new MssqlDialect({

--- a/backend/src/services/database/db.ts
+++ b/backend/src/services/database/db.ts
@@ -234,6 +234,10 @@ if (dbType === DatabaseType.POSTGRESQL) {
     idleTimeoutMillis: 30000,
   });
 
+  pool.on('error', (err) => {
+    logger.error({ err }, '[db] Unexpected error on idle PostgreSQL client');
+  });
+
   db = new Kysely<Database>({
     dialect: new PostgresDialect({
       pool,


### PR DESCRIPTION
The Node.js backend was crashing due to an unhandled `read ETIMEDOUT` error originating from an idle database connection pool. In `node-postgres` (`pg`), when an idle client connection encounters a network or backend error (such as a timeout or dropped connection), it emits an `'error'` event on the pool. If this event is unhandled, Node.js escalates it to an uncaught exception, crashing the entire application.

This change adds an `.on('error', ...)` event listener to the PostgreSQL connection pool (via the `pg` module) exactly where the main database pool is instantiated. Catching and logging this error completely prevents the crash while allowing the pool to automatically discard the faulty connection and heal itself.

---
*PR created automatically by Jules for task [4586400634132794944](https://jules.google.com/task/4586400634132794944) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database connection-pool error handling and logging for PostgreSQL and MSSQL/Azure SQL. Unexpected pool/connection errors are now captured and logged to aid monitoring and troubleshooting. No public APIs or exported declarations were changed; this is an internal stability and observability update with minimal surface impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->