### PR TITLE
🎨 Palette: [UX improvement] Explicit UUID tooltip in Whois

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -20,6 +20,6 @@
 
 ## 2024-05-24 - Micro-UX Clarity in Command Tooltips
 
-**Learning:** Vague tooltip messages in `HoverEvent`s, such as "Click to fill" or "Click to run", can confuse users about what exactly is being filled or run, especially when commands involve external data like UUIDs or complex configuration values.
+**Learning:** Vague tooltip messages in `HoverEvent`s, such as "Click to fill command" or "Click to run command", can confuse users about what exactly is being filled or run, especially when commands involve external data like UUIDs or complex configuration values.
 
-**Action:** Ensure `HoverEvent` tooltips are explicit about the outcome. For standard commands, prefer "Click to fill command" or "Click to run command". For specific data, use "Click to fill UUID", etc.
+**Action:** Ensure `HoverEvent` tooltips are explicit about the outcome. For standard commands, prefer "Click to fill command" or "Click to run command". For specific data, use "Click to fill UUID", etc. When using `CommandUtils.createClickableCommand`, utilize the `hoverTextOverride` parameter to provide this explicitly descriptive tooltip text.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
@@ -25,7 +25,7 @@ object CommandUtils {
         hoverTextOverride: String? = null
     ): IChatComponent {
         val action = if (run) ClickEvent.Action.RUN_COMMAND else ClickEvent.Action.SUGGEST_COMMAND
-        val hoverText = hoverTextOverride ?: if (run) "${ChatColor.GREEN}Click to run command" else "${ChatColor.GREEN}Click to fill command"
+        val hoverText = hoverTextOverride ?: "${ChatColor.GREEN}Click to ${if (run) "run" else "fill"} command"
         val text = displayText ?: "${ChatColor.GOLD}$command"
 
         return ChatComponentText(text).apply {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
@@ -21,10 +21,11 @@ object CommandUtils {
         command: String,
         run: Boolean = false,
         suggestedCommand: String = command,
-        displayText: String? = null
+        displayText: String? = null,
+        hoverTextOverride: String? = null
     ): IChatComponent {
         val action = if (run) ClickEvent.Action.RUN_COMMAND else ClickEvent.Action.SUGGEST_COMMAND
-        val hoverText = if (run) "${ChatColor.GREEN}Click to run command" else "${ChatColor.GREEN}Click to fill command"
+        val hoverText = hoverTextOverride ?: if (run) "${ChatColor.GREEN}Click to run command" else "${ChatColor.GREEN}Click to fill command"
         val text = displayText ?: "${ChatColor.GOLD}$command"
 
         return ChatComponentText(text).apply {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisService.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisService.kt
@@ -150,9 +150,8 @@ object WhoisService {
         val nickedText = if (result.nicked) " ${ChatColor.GRAY}(nicked)" else ""
 
         val nameComponent = CommandUtils.createClickableCommand(
-            result.displayName,
+            result.uuid.toString(),
             run = false,
-            suggestedCommand = result.uuid.toString(),
             displayText = "${ChatColor.YELLOW}${result.displayName}",
             hoverTextOverride = "${ChatColor.GREEN}Click to fill UUID"
         )

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisService.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisService.kt
@@ -153,7 +153,8 @@ object WhoisService {
             result.displayName,
             run = false,
             suggestedCommand = result.uuid.toString(),
-            displayText = "${ChatColor.YELLOW}${result.displayName}"
+            displayText = "${ChatColor.YELLOW}${result.displayName}",
+            hoverTextOverride = "${ChatColor.GREEN}Click to fill UUID"
         )
 
         return nameComponent.appendSibling(


### PR DESCRIPTION
💡 What: Added a new `hoverTextOverride` parameter to `CommandUtils.createClickableCommand` allowing specific, custom context to replace generic tooltips. Used this new capability in `WhoisService.kt` to update the name component tooltip to explicitly display "Click to fill UUID".
🎯 Why: Vague generic tooltips ("Click to fill command") can be confusing when dealing with external or complex data. Explicitly stating the action output helps user confidence and understanding.
📸 Before/After: Hovering over the parsed name from `/levelhead whois` previously showed "Click to fill command". Now, it displays "Click to fill UUID".
♿ Accessibility: Increased micro-UX cognitive clarity. Users are explicitly informed they are extracting and utilizing a UUID, rather than an arbitrary command component.

---
*PR created automatically by Jules for task [16592941400993315703](https://jules.google.com/task/16592941400993315703) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced tooltip messages for interactive commands with clearer, more descriptive action descriptions (e.g., "Click to fill command" instead of generic prompts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->