### PR TITLE
feat: add proxy server support via 'Force On All Servers' option

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -147,15 +147,15 @@ object Levelhead {
     private val minecraft: Minecraft
         get() = Minecraft.getMinecraft()
 
-fun isOnHypixel(): Boolean {
-    if (LevelheadConfig.forceEnabled) return true
-    if (minecraft.isSingleplayer) {
-        return false
+    fun isOnHypixel(): Boolean {
+        if (LevelheadConfig.forceEnabled) return true
+        if (minecraft.isSingleplayer) {
+            return false
+        }
+        val serverIp = minecraft.currentServerData?.serverIP ?: return false
+        val normalized = serverIp.lowercase(Locale.ROOT)
+        return normalized.contains("hypixel")
     }
-    val serverIp = minecraft.currentServerData?.serverIP ?: return false
-    val normalized = serverIp.lowercase(Locale.ROOT)
-    return normalized.contains("hypixel")
-}
 
     fun sendChat(message: String) {
         val formatted = "${ChatColor.AQUA}[Levelhead] ${ChatColor.RESET}$message"

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -147,14 +147,15 @@ object Levelhead {
     private val minecraft: Minecraft
         get() = Minecraft.getMinecraft()
 
-    fun isOnHypixel(): Boolean {
-        if (minecraft.isSingleplayer) {
-            return false
-        }
-        val serverIp = minecraft.currentServerData?.serverIP ?: return false
-        val normalized = serverIp.lowercase(Locale.ROOT)
-        return normalized.contains("hypixel")
+fun isOnHypixel(): Boolean {
+    if (LevelheadConfig.forceEnabled) return true
+    if (minecraft.isSingleplayer) {
+        return false
     }
+    val serverIp = minecraft.currentServerData?.serverIP ?: return false
+    val normalized = serverIp.lowercase(Locale.ROOT)
+    return normalized.contains("hypixel")
+}
 
     fun sendChat(message: String) {
         val formatted = "${ChatColor.AQUA}[Levelhead] ${ChatColor.RESET}$message"

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -823,26 +823,36 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
             save()
             BedwarsFetcher.resetWarnings()
         }
-    @Dropdown(
-        name = "DNS Resolution Mode",
-        description = "Choose how to resolve domain names. IPv4 First is recommended for most users.",
-        category = "Advanced",
-        options = ["IPv4 Only", "IPv4 First", "System Default"]
-    )
-    var dnsModeIndex: Int = 1 // Default to IPv4 First
-        set(value) {
-            field = value.coerceIn(0, DnsMode.entries.size - 1)
-            save()
-        }
+@Dropdown(
+    name = "DNS Resolution Mode",
+    description = "Choose how to resolve domain names. IPv4 First is recommended for most users.",
+    category = "Advanced",
+    options = ["IPv4 Only", "IPv4 First", "System Default"]
+)
+var dnsModeIndex: Int = 1 // Default to IPv4 First
+set(value) {
+    field = value.coerceIn(0, DnsMode.entries.size - 1)
+    save()
+}
 
+@Switch(
+    name = "Force On All Servers",
+    description = "Enable Levelhead on all servers, not just Hypixel. Useful when using proxy services that change your server IP.",
+    category = "Advanced"
+)
+var forceEnabled: Boolean = false
+set(value) {
+    field = value
+    save()
+}
 
-    @Info(
-        text = "Proxy Auth Token is recommended when using a private backend.",
-        type = InfoType.INFO,
-        category = "Advanced"
-    )
-    @Transient
-    var proxyAuthInfo: String = ""
+@Info(
+    text = "Proxy Auth Token is recommended when using a private backend.",
+    type = InfoType.INFO,
+    category = "Advanced"
+)
+@Transient
+var proxyAuthInfo: String = ""
 
     @Text(
         name = "Proxy Auth Token",
@@ -1367,12 +1377,13 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
         hideIf("proxyBaseUrl") { !showAdvancedOptions }
         hideIf("proxyAuthToken") { !showAdvancedOptions }
         hideIf("communitySubmitSecret") { !showAdvancedOptions }
-        hideIf("customDatabaseUrl") { !showAdvancedOptions }
-        hideIf("proxyUrlWarning") { !showAdvancedOptions || !proxyEnabled || proxyBaseUrl.isNotBlank() }
-        hideIf("proxyAuthInfo") { !showAdvancedOptions }
-        hideIf("dnsModeIndex") { !showAdvancedOptions }
+hideIf("customDatabaseUrl") { !showAdvancedOptions }
+    hideIf("proxyUrlWarning") { !showAdvancedOptions || !proxyEnabled || proxyBaseUrl.isNotBlank() }
+    hideIf("proxyAuthInfo") { !showAdvancedOptions }
+    hideIf("dnsModeIndex") { !showAdvancedOptions }
+    hideIf("forceEnabled") { !showAdvancedOptions }
 
-        hideIf("bedwarsCustomFooterFormat") {
+    hideIf("bedwarsCustomFooterFormat") {
             bedwarsStatMode != BedwarsStatMode.CUSTOM
         }
         hideIf("duelsCustomFooterFormat") {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/config/LevelheadConfig.kt
@@ -823,36 +823,37 @@ object LevelheadConfig : Config(Mod("BedWars Levelhead", ModType.HYPIXEL), "bedw
             save()
             BedwarsFetcher.resetWarnings()
         }
-@Dropdown(
-    name = "DNS Resolution Mode",
-    description = "Choose how to resolve domain names. IPv4 First is recommended for most users.",
-    category = "Advanced",
-    options = ["IPv4 Only", "IPv4 First", "System Default"]
-)
-var dnsModeIndex: Int = 1 // Default to IPv4 First
-set(value) {
-    field = value.coerceIn(0, DnsMode.entries.size - 1)
-    save()
-}
 
-@Switch(
-    name = "Force On All Servers",
-    description = "Enable Levelhead on all servers, not just Hypixel. Useful when using proxy services that change your server IP.",
-    category = "Advanced"
-)
-var forceEnabled: Boolean = false
-set(value) {
-    field = value
-    save()
-}
+    @Dropdown(
+        name = "DNS Resolution Mode",
+        description = "Choose how to resolve domain names. IPv4 First is recommended for most users.",
+        category = "Advanced",
+        options = ["IPv4 Only", "IPv4 First", "System Default"]
+    )
+    var dnsModeIndex: Int = 1 // Default to IPv4 First
+        set(value) {
+            field = value.coerceIn(0, DnsMode.entries.size - 1)
+            save()
+        }
 
-@Info(
-    text = "Proxy Auth Token is recommended when using a private backend.",
-    type = InfoType.INFO,
-    category = "Advanced"
-)
-@Transient
-var proxyAuthInfo: String = ""
+    @Switch(
+        name = "Force On All Servers",
+        description = "Enable Levelhead on all servers, not just Hypixel. Useful when using proxy services that change your server IP.",
+        category = "Advanced"
+    )
+    var forceEnabled: Boolean = false
+        set(value) {
+            field = value
+            save()
+        }
+
+    @Info(
+        text = "Proxy Auth Token is recommended when using a private backend.",
+        type = InfoType.INFO,
+        category = "Advanced"
+    )
+    @Transient
+    var proxyAuthInfo: String = ""
 
     @Text(
         name = "Proxy Auth Token",


### PR DESCRIPTION
## Summary
When using proxy services like Hypicle that route connections through their own servers, the server IP changes and causes `isOnHypixel()` to return `false`, disabling Levelhead entirely.

This PR adds a **"Force On All Servers"** config option (hidden behind advanced options) that bypasses the server IP check, allowing Levelhead to work with such proxy services.

## Changes
- **LevelheadConfig.kt**: Added new `"Force On All Servers"` toggle in Advanced settings, hidden behind `showAdvancedOptions`
- **Levelhead.kt**: Modified `isOnHypixel()` to check `LevelheadConfig.forceEnabled` first

## How to use
1. Enable "Show Advanced Options" in the config
2. Enable "Force On All Servers"
3. Levelhead will now work on proxy services that route through their own servers

Note: The actual stats fetching and display still only activates when in appropriate game modes (BedWars, Duels, SkyWars) detected via scoreboard/chat patterns.