### PR TITLE
🧱 Mason: Refactor object allocation inside hot flushHistoryBuffer loop

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -34,3 +34,7 @@
 **Tech Debt:** Inline `as Record<string, unknown>` type assertions were repeatedly used to bypass type checking across various validation functions in Node.js backend (`submissionService.ts`, `statsCache.ts`, `hypixel.ts`, etc.).
 **Learning:** This approach undermines the strict null/array checking required for robust TypeScript, particularly since `typeof null` and `typeof []` both evaluate to `'object'`, posing logic bugs.
 **Prevention:** Always rely on a central type guard utility like `isNonArrayObject` that checks for `value !== null && typeof value === 'object' && !Array.isArray(value)` to strictly narrow unknown objects before safely accessing their properties.
+## 2026-04-20 - Eliminate spread object allocations in hot loops
+**Tech Debt:** Found an unnecessary object allocation using the spread operator (`const updatedRecord = { ...record, retryCount };`) inside the hot `flushHistoryBuffer` loop.
+**Learning:** In very hot paths (like processing large batch arrays or flushing memory history queues continuously), native functional destructuring or spread allocations generate unnecessary memory overhead and pressure on the Garbage Collector per iteration.
+**Prevention:** Rather than allocating new objects, mutate the existing properties on objects directly inside loops when processing batches before passing them to queues or dead letters.

--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -34,7 +34,9 @@
 **Tech Debt:** Inline `as Record<string, unknown>` type assertions were repeatedly used to bypass type checking across various validation functions in Node.js backend (`submissionService.ts`, `statsCache.ts`, `hypixel.ts`, etc.).
 **Learning:** This approach undermines the strict null/array checking required for robust TypeScript, particularly since `typeof null` and `typeof []` both evaluate to `'object'`, posing logic bugs.
 **Prevention:** Always rely on a central type guard utility like `isNonArrayObject` that checks for `value !== null && typeof value === 'object' && !Array.isArray(value)` to strictly narrow unknown objects before safely accessing their properties.
+
 ## 2026-04-20 - Eliminate spread object allocations in hot loops
+
 **Tech Debt:** Found an unnecessary object allocation using the spread operator (`const updatedRecord = { ...record, retryCount };`) inside the hot `flushHistoryBuffer` loop.
 **Learning:** In very hot paths (like processing large batch arrays or flushing memory history queues continuously), native functional destructuring or spread allocations generate unnecessary memory overhead and pressure on the Garbage Collector per iteration.
 **Prevention:** Rather than allocating new objects, mutate the existing properties on objects directly inside loops when processing batches before passing them to queues or dead letters.

--- a/backend/src/services/history.ts
+++ b/backend/src/services/history.ts
@@ -322,13 +322,12 @@ async function flushHistoryBuffer(): Promise<void> {
 
     for (let i = 0; i < batch.length; i++) {
       const record = batch[i];
-      const retryCount = (record.retryCount || 0) + 1;
-      const updatedRecord = { ...record, retryCount };
+      record.retryCount = (record.retryCount || 0) + 1;
 
-      if (retryCount >= MAX_RETRY_ATTEMPTS) {
-        deadLettered.push(updatedRecord);
+      if (record.retryCount >= MAX_RETRY_ATTEMPTS) {
+        deadLettered.push(record);
       } else {
-        toRetry.push(updatedRecord);
+        toRetry.push(record);
       }
     }
 


### PR DESCRIPTION
💡 What: Eliminated a redundant object allocation inside `flushHistoryBuffer` within `history.ts`.
🎯 Why: Utilizing object spreading (`{ ...record }`) per iteration within a hot polling and retry loop generates excessive intermediate memory overhead. This forces the GC to frequently clear these short-lived objects under high load.
🛠️ How: Replaced the spread operator with direct property mutation (`record.retryCount = ...`) before pushing the reference to the retry or dead-letter queues.
✅ Verification: `npm run build` completed successfully without type errors, and all 96 unit tests passed in `npx jest` (verified 0 regressions).

---
*PR created automatically by Jules for task [14120314067542749773](https://jules.google.com/task/14120314067542749773) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced per-iteration object allocations in a hot error-handling path to improve performance and lower memory churn.
* **Documentation**
  * Added a learning entry documenting the optimization and its date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->