### PR TITLE
🎨 Palette: [Make mod title clickable to open GUI]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,7 @@
 
 **Learning:** Vague tooltips like "Click to fill command" or "Click to run command" do not provide enough context for users navigating interactive chat configurations.
 **Action:** Always provide explicitly descriptive tooltips detailing exactly what happens (e.g., "Click to fill apply command", "Click to view display settings") using the `hoverTextOverride` parameter when creating `CommandUtils.createClickableCommand` elements.
+
+## 2024-05-24 - Clickable Mod Title for GUI Discovery
+**Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
+**Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -123,7 +123,11 @@ class LevelheadCommand {
         }
 
         val mainComponent = ChatComponentText("").apply {
-            appendSibling(ChatComponentText("BedWars Levelhead ").apply { chatStyle.color = ChatColor.AQUA })
+            appendSibling(ChatComponentText("BedWars Levelhead ").apply {
+                chatStyle.color = ChatColor.AQUA
+                chatStyle.chatClickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/levelhead gui")
+                chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open settings GUI"))
+            })
             appendSibling(ChatComponentText("v${Levelhead.VERSION}").apply { chatStyle.color = ChatColor.GOLD })
             appendSibling(ChatComponentText(": ").apply { chatStyle.color = ChatColor.YELLOW })
             appendSibling(statusComponent)

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -122,12 +122,13 @@ class LevelheadCommand {
             chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText(hoverText).apply { chatStyle.color = if (enabled) ChatColor.RED else ChatColor.GREEN })
         }
 
-        val mainComponent = ChatComponentText("").apply {
-            appendSibling(ChatComponentText("BedWars Levelhead ").apply {
-                chatStyle.color = ChatColor.AQUA
-                chatStyle.chatClickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/levelhead gui")
-                chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open settings GUI"))
-            })
+ val mainComponent = ChatComponentText("").apply {
+ appendSibling(CommandUtils.createClickableCommand(
+ "/levelhead gui",
+ run = true,
+ displayText = "${ChatColor.AQUA}BedWars Levelhead ",
+ hoverTextOverride = "${ChatColor.GREEN}Click to open settings GUI"
+ ))
             appendSibling(ChatComponentText("v${Levelhead.VERSION}").apply { chatStyle.color = ChatColor.GOLD })
             appendSibling(ChatComponentText(": ").apply { chatStyle.color = ChatColor.YELLOW })
             appendSibling(statusComponent)


### PR DESCRIPTION
💡 What: Made the "BedWars Levelhead" title text in the main `/levelhead` command output clickable, which instantly opens the OneConfig settings GUI.
🎯 Why: Users often type `/levelhead` to see what the mod is and its status, but the list of subcommands can be overwhelming. Clicking the mod's name is an intuitive, discoverable shortcut to reach the main configuration UI without needing to know or type the `/levelhead gui` subcommand.
📸 Before/After: Visual change in chat interaction (adds a hover text and makes it a button).
♿ Accessibility: Reduces keyboard typing required to reach the main settings, especially helpful for users less familiar with Minecraft commands.

---
*PR created automatically by Jules for task [10822407875593884441](https://jules.google.com/task/10822407875593884441) started by @beenycool*