### PR TITLE
🎨 Palette: [UX improvement] Add explicit tooltips to interactive chat commands

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+## 2026-04-25 - Explicit Tooltips for Confirmation and Status Links
+**Learning:** Default tooltips like "Click to run command" are insufficient for critical pending actions or status links. Users benefit from explicitly descriptive hover texts that state exactly what the link will do. Also, support URLs in error messages should link directly to issue trackers rather than repository roots.
+**Action:** Always utilize the `hoverTextOverride` parameter in `CommandUtils.buildInteractiveFeedback` to provide clear context (e.g., "Click to confirm pending action"), and point GitHub URLs directly to the `/issues` endpoint.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -542,9 +542,10 @@ class LevelheadCommand {
                     messagePrefix = "${ChatColor.RED}Unexpected error while fetching stats. Try ",
                     command = "/levelhead status",
                     run = true,
-                    suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
+                    suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: ",
+                    hoverTextOverride = "${ChatColor.GREEN}Click to check proxy status"
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -1334,13 +1335,15 @@ private fun requireConfirmation(warningMessage: String, action: () -> Unit) {
             messagePrefix = "${ChatColor.RED}An action is already pending. Please ",
             command = "/levelhead confirm",
             run = true,
-            suffix = "${ChatColor.RED} or "
+            suffix = "${ChatColor.RED} or ",
+            hoverTextOverride = "${ChatColor.GREEN}Click to confirm pending action"
         )
         errorMsg.appendSibling(CommandUtils.buildInteractiveFeedback(
             messagePrefix = "",
             command = "/levelhead cancel",
             run = true,
-            suffix = "${ChatColor.RED} it."
+            suffix = "${ChatColor.RED} it.",
+            hoverTextOverride = "${ChatColor.RED}Click to cancel pending action"
         ))
         CommandUtils.sendPrefixedChat(errorMsg)
         return

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -51,9 +51,10 @@ class WhoisCommand {
                     messagePrefix = "${ChatColor.RED}Unexpected error while fetching stats. Try ",
                     command = "/levelhead status",
                     run = true,
-                    suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
+                    suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: ",
+                    hoverTextOverride = "${ChatColor.GREEN}Click to check proxy status"
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }


### PR DESCRIPTION
💡 What: Added explicit `hoverTextOverride` tooltips to the pending action `[Confirm]` and `[Cancel]` prompts, as well as the `/levelhead status` fallback error message. The GitHub URL in the error message was also updated to point directly to the `/issues` page.
🎯 Why: The default "Click to run command" tooltip is vague and lacks context, especially for critical destructive or state-changing actions. Providing explicit text like "Click to confirm pending action" improves clarity and accessibility. Directing users straight to the issues page saves them an extra navigation step.
📸 Before/After: Tooltips for pending actions changed from "Click to run command" to "Click to confirm/cancel pending action". The GitHub link now navigates to the issues page instead of the repo root.
♿ Accessibility: Improves screen reader context and general cognitive accessibility by clarifying the explicit outcome of interactive chat components.

---
*PR created automatically by Jules for task [4285490768303658672](https://jules.google.com/task/4285490768303658672) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom hover tooltips to interactive chat feedback, providing explicit instructions for confirmation and cancellation actions
  * Enhanced error messages with improved hover text for status indicators and proxy connection information
  * Updated support links to direct users to the dedicated issues page for better assistance and problem reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->