### PR TITLE
🎨 Palette: [UX improvement] Point GitHub error links directly to /issues

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+
+## 2024-05-24 - Issue Links
+**Learning:** Pointing GitHub repository links in error messages directly to the `/issues` page saves users an extra navigation step when they need to report a problem.
+**Action:** When providing links for error reporting, use the `/issues` URL (e.g. `https://github.com/user/repo/issues`) instead of the repository root.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }


### PR DESCRIPTION
💡 What: Updated GitHub repository links in error messages to point directly to the `/issues` page.
🎯 Why: Saves users an extra navigation step when they encounter an error and want to report it.
📸 Before/After: Link was `https://github.com/beenycool/bedwars-level-head/`, is now `https://github.com/beenycool/bedwars-level-head/issues`.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [18165990905984882012](https://jules.google.com/task/18165990905984882012) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error message links to direct users to the issues page instead of the repository root, enabling more efficient issue reporting.

* **Documentation**
  * Added documentation clarifying that error-reporting links should point directly to the issues page rather than the repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->