### PR TITLE
🎨 Palette: [UX improvement] Direct GitHub links to issues page

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -53,7 +53,7 @@ class WhoisCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }


### PR DESCRIPTION
💡 **What**: Updated GitHub URLs in error messages to point directly to `https://github.com/beenycool/bedwars-level-head/issues` instead of the repository root.
🎯 **Why**: When a user encounters an error and the mod prompts them to "make an issue on GitHub", directing them to the root page requires an additional, tedious click to find the issues tab. Linking directly to the issues page reduces friction and improves the overall experience of submitting feedback.
📸 **Before/After**: The clickable text "${ChatColor.AQUA}GitHub." now navigates to `/issues`.
♿ **Accessibility**: N/A, purely an interaction/workflow improvement.

---
*PR created automatically by Jules for task [16027167894472167228](https://jules.google.com/task/16027167894472167228) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now link to the GitHub issues page instead of the repository homepage, improving user access to support resources and issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->