### PR TITLE
⚡ Bolt: Optimize chunk allocation in hypixelTracker flush

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -131,3 +131,6 @@
 **Learning:** In ESBuild output, interpolating `JSON.stringify(data)` into a template string in Node script blocks can break code if ASI decides that the `{"json": "content"}` object was meant to evaluate, then missing a semicolon breaks syntax execution logic resulting in `jsonForFrontend.filter is not a function`.
 
 **Action:** When injecting backend JSON into inline template strings (e.g. `const html = \`…\``-style template literals), wrap the payload in `JSON.parse(decodeURIComponent("..."))` rather than interpolating raw object syntax.
+## 2026-04-29 - [Avoid lockfile pollution on build checks]
+**Learning:** Running pnpm install without `--frozen-lockfile` in verification steps can unintentionally pull in root level dependencies and pollute lockfiles.
+**Action:** Always run `pnpm install --frozen-lockfile` during tests/build checks to maintain lockfile integrity.

--- a/backend/src/services/hypixelTracker.ts
+++ b/backend/src/services/hypixelTracker.ts
@@ -140,16 +140,15 @@ async function flushHypixelCallBuffer(): Promise<void> {
         const chunkEnd = Math.min(inflightOffset + maxRecordsPerChunk, inflightBatch.length);
         const chunk = inflightBatch.slice(inflightOffset, chunkEnd);
 
-        // Optimized from flatMap to reduce array allocations
-        const PARAMS_PER_RECORD = 2;
-        const params = new Array(chunk.length * PARAMS_PER_RECORD);
+        // ⚡ Bolt: Removed dead raw SQL params array and replaced chunk.map() with a pre-sized array loop
+        // to avoid O(N) dynamic array allocations and closure overhead on high-throughput paths.
+        const values = new Array(chunk.length);
         for (let i = 0; i < chunk.length; i++) {
-          params[i * PARAMS_PER_RECORD] = chunk[i].calledAt;
-          params[i * PARAMS_PER_RECORD + 1] = chunk[i].uuid;
+          const item = chunk[i];
+          values[i] = { called_at: item.calledAt, uuid: item.uuid };
         }
 
         try {
-          const values = chunk.map(item => ({ called_at: item.calledAt, uuid: item.uuid }));
           await pool.insertInto('hypixel_api_calls').values(values).execute();
           // Success: advance offset. Items before offset are in DB; items at/after offset are pending.
           inflightOffset += chunk.length;


### PR DESCRIPTION
💡 What: Replaced dead `params` raw SQL array allocation loop and the subsequent `chunk.map()` allocation with a single loop creating a pre-sized array containing the precise payload needed for Kysely insertion.
🎯 Why: `chunk.map()` creates an intermediate O(N) array allocation and incurs closure overhead on every batch flush, which can become a bottleneck when writing large batches. The prior `params` array logic was dead code originally intended for a raw SQL query string implementation.
📊 Impact: Decreases dynamic memory allocations per batch, significantly lowering garbage collector pressure during heavy bursts of Hypixel tracker background updates.
🔬 Measurement: Verify using `pnpm test tests/services/hypixelTracker.test.ts` to ensure data buffering and insertion still work flawlessly.

---
*PR created automatically by Jules for task [14523989194118868545](https://jules.google.com/task/14523989194118868545) started by @beenycool*