### PR TITLE
🎨 Palette: [UX improvement] Direct GitHub Links to Issues Page

### DIFF
--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -53,7 +53,7 @@ class WhoisCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }


### PR DESCRIPTION
💡 What: Updated GitHub repository links in error messages to point directly to the `/issues` page instead of the repository root.
🎯 Why: Saves users an extra navigation step when they encounter an error and are prompted to report it.
📸 Before/After: No visual change, just the URL destination.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [10007435458625082876](https://jules.google.com/task/10007435458625082876) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error feedback messages to direct users to the GitHub issues page instead of the repository root, improving issue reporting workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->