### PR TITLE
🎨 Palette: [UX improvement] Direct GitHub links to issues page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,6 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+## 2026-05-03 - Direct GitHub Issue Links
+**Learning:** When displaying repository links in error messages that suggest opening a bug, users save an extra click and cognitive load if the link points directly to the `/issues` page rather than the root repository URL.
+**Action:** Always append `/issues` to GitHub repository URLs when the context is error reporting or bug submission.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -53,7 +53,7 @@ class WhoisCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }


### PR DESCRIPTION
💡 What: Updated GitHub links in error messages to point directly to the `/issues` page.
🎯 Why: Saves users an extra navigation step when they encounter an error and want to report it, reducing friction in the bug reporting process.
📸 Before/After: N/A (Console text/Chat link change)
♿ Accessibility: Reduces cognitive load and physical clicks required to reach the relevant reporting page.

---
*PR created automatically by Jules for task [11746528178903933116](https://jules.google.com/task/11746528178903933116) started by @beenycool*