### PR TITLE
🎨 Palette: [UX improvement] Make [Levelhead] chat prefix clickable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,8 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+
+## 2024-05-24 - Mod Title Discoverability
+
+**Learning:** Users often overlook the GUI command (`/levelhead gui`) in favor of standard chat commands. The globally visible mod title `[Levelhead]` prefix serves as an excellent, omnipresent anchor for a shortcut.
+**Action:** Make the universally appended `[Levelhead]` chat prefix clickable to directly run the mod's configuration command, accompanied by a clear `HoverEvent` tooltip. Ensure isolated styling by chaining sibling text components.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
@@ -10,8 +10,13 @@ import net.minecraft.util.EnumChatFormatting as ChatColor
 object CommandUtils {
     fun sendPrefixedChat(component: IChatComponent) {
         val minecraft = Minecraft.getMinecraft()
-        val formatted = ChatComponentText("${ChatColor.AQUA}[Levelhead] ${ChatColor.RESET}")
-        formatted.appendSibling(component)
+        val formatted = ChatComponentText("")
+            .appendSibling(ChatComponentText("${ChatColor.AQUA}[Levelhead]").apply {
+                chatStyle.chatClickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/levelhead gui")
+                chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open settings GUI"))
+            })
+            .appendSibling(ChatComponentText(" ${ChatColor.RESET}"))
+            .appendSibling(component)
         minecraft.addScheduledTask {
             minecraft.thePlayer?.addChatMessage(formatted)
         }


### PR DESCRIPTION
💡 What: Made the globally appended `[Levelhead]` chat prefix clickable, executing the `/levelhead gui` command to open the configuration menu. Added an explicit `HoverEvent` tooltip.
🎯 Why: Improves feature discoverability by providing an omnipresent, intuitive shortcut to access the mod's configuration from any mod chat message, reducing the need to remember or type the GUI command.
📸 Before/After: The `[Levelhead]` prefix now highlights green on hover and shows "Click to open settings GUI".
♿ Accessibility: Provides a faster, mouse-friendly alternative to typing commands, improving usability for users navigating through chat.

---
*PR created automatically by Jules for task [4989821306930851135](https://jules.google.com/task/4989821306930851135) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Levelhead chat prefix is now clickable to open GUI configuration with hover text tooltips.

* **Documentation**
  * Added learning materials on interactive UI component patterns for chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->