### PR TITLE
🧱 Mason: [Refactor type]

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -46,3 +46,8 @@
 **Tech Debt:** Type `any`/`unknown` casting like `submission as unknown as import('./hypixel').HypixelPlayerResponse` was used for type coercion in `SubmissionService`.
 **Learning:** Chaining type casts via `unknown` completely disables compiler type checks and allows arbitrarily structured user input to bypass strict TS protections, risking runtime errors.
 **Prevention:** Rather than inline casting, introduce a strict structural type guard checking primitive and deep object fields (`isNonArrayObject(value) && typeof value.success === 'boolean'`) to properly narrow the type before property access.
+
+## 2025-05-04 - Generic Type Parameters in Utilities Processing Arrays of Objects
+**Tech Debt:** Utilities that process an array of generic objects (like `toCSV`) used strict parameter types such as `Record<string, unknown>[]`, forcing callers in `routes/stats.ts` to implement unsafe type coercions (`as unknown as Record<string, unknown>[]`) when passing their strongly-typed domain objects.
+**Learning:** Forcing domain objects into strict maps like `Record<string, unknown>[]` nullifies TypeScript's ability to natively infer and bridge interface types into generic object shapes. This encourages widespread `as unknown` masking, turning off compiler type checking entirely at caller boundaries.
+**Prevention:** In utilities that iterate over generic object arrays, employ generic type parameters (`<T extends object>(data: T[])`). This allows TypeScript to automatically inherit and map the types from the caller, retaining full strictness and eliminating the need for `as unknown` coercions.

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -193,7 +193,7 @@ router.get('/csv', async (req, res) => {
       endDate: validEndDate,
       });
 
-      const csv = toCSV(data as unknown as Record<string, unknown>[]);
+      const csv = toCSV(data);
 
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', 'attachment; filename="memory_stats.csv"');
@@ -216,7 +216,7 @@ router.get('/csv', async (req, res) => {
     });
     const data = (Array.isArray(rawData) ? rawData : []).map((entry) =>
       normalizePlayerQuerySummaryEntry(entry),
-    ) as unknown as Record<string, unknown>[];
+    );
 
     const csv = toCSV(data);
 

--- a/backend/src/util/csv.ts
+++ b/backend/src/util/csv.ts
@@ -27,9 +27,9 @@ const escapeCell = (val: unknown): string => {
   return sanitized;
 };
 
-export function toCSV(data: Record<string, unknown>[]): string {
+export function toCSV<T extends object>(data: T[]): string {
   if (data.length === 0) return '';
-  const headers = Object.keys(data[0]);
+  const headers = Object.keys(data[0] as Record<string, unknown>);
 
   // ⚡ Bolt: Replaced .map().join('\n') and intermediate array allocations with direct string concatenation (+=) and a single loop to reduce GC pressure when generating large CSVs
   const numRows = data.length;
@@ -44,7 +44,7 @@ export function toCSV(data: Record<string, unknown>[]): string {
   }
 
   for (let r = 0; r < numRows; r++) {
-    const row = data[r];
+    const row = data[r] as Record<string, unknown>;
     if (numCols === 0) {
       result += '\n';
       continue;


### PR DESCRIPTION
💡 **What:** Refactored the `toCSV` utility to use a generic type parameter (`<T extends object>`) instead of a strict `Record<string, unknown>[]` parameter.
🎯 **Why:** To eliminate the need for callers (e.g. `routes/stats.ts`) to rely on unsafe, chaining type assertions like `as unknown as Record<string, unknown>[]` when passing domain objects to the utility.
🛠️ **How:** 
1. Updated `toCSV` signature to `export function toCSV<T extends object>(data: T[]): string`.
2. Inside `toCSV`, cast individual array elements to `Record<string, unknown>` to safely iterate over object keys without throwing compiler errors.
3. Removed `as unknown as Record<string, unknown>[]` type assertions from the call sites in `backend/src/routes/stats.ts`.
4. Documented the learning in `.jules/mason.md`.
✅ **Verification:** Verified by compiling the backend code (`pnpm run build`), running unit tests (`npx jest`), and ensuring no behavioral logic or schemas were modified.

---
*PR created automatically by Jules for task [7773486317485138065](https://jules.google.com/task/7773486317485138065) started by @beenycool*