### PR TITLE
🎨 Palette: [UX improvement] Interactive Chat Mod Prefix & Link Targeting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+
+## 2024-05-25 - Interactive Chat Mod Prefix & Link Targeting
+**Learning:** Users often run base commands (`/levelhead`) to see status, but miss commands like `/levelhead gui`. Additionally, when providing GitHub repository links in error messages or interactive chat components, pointing the URL to the repository root forces users to navigate to the issues page manually.
+**Action:** Make the primary mod title text in the status header clickable (with an explicitly descriptive `HoverEvent` tooltip) using `ClickEvent.Action.RUN_COMMAND` to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface. When providing GitHub links for bug reporting, point the URL directly to the `/issues` page (e.g., `https://github.com/user/repo/issues`) instead of the repository root to save users an extra navigation step.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
@@ -10,8 +10,14 @@ import net.minecraft.util.EnumChatFormatting as ChatColor
 object CommandUtils {
     fun sendPrefixedChat(component: IChatComponent) {
         val minecraft = Minecraft.getMinecraft()
-        val formatted = ChatComponentText("${ChatColor.AQUA}[Levelhead] ${ChatColor.RESET}")
-        formatted.appendSibling(component)
+        val prefix = ChatComponentText("${ChatColor.AQUA}[Levelhead]").apply {
+            chatStyle.chatClickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/levelhead gui")
+            chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open settings GUI"))
+        }
+        val formatted = ChatComponentText("")
+            .appendSibling(prefix)
+            .appendSibling(ChatComponentText(" ${ChatColor.RESET}"))
+            .appendSibling(component)
         minecraft.addScheduledTask {
             minecraft.thePlayer?.addChatMessage(formatted)
         }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -53,7 +53,7 @@ class WhoisCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }


### PR DESCRIPTION
💡 **What:** 
- Made the `[Levelhead]` prefix in chat messages clickable to immediately open the settings GUI (`/levelhead gui`), along with an explicit hover tooltip.
- Updated GitHub URLs in error messages to point directly to the `/issues` page rather than the repository root.

🎯 **Why:** 
- Improves discoverability of the main configuration GUI, saving users from hunting through command lists. 
- Reduces friction when a user encounters a bug by bringing them directly to the issue tracker.

📸 **Before/After:** N/A (Chat component internal formatting).

♿ **Accessibility:** Added descriptive `HoverEvent` tooltips to clarify the action before clicking.

---
*PR created automatically by Jules for task [7374477313627467770](https://jules.google.com/task/7374477313627467770) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat prefix is now clickable and opens the mod GUI directly with hover tooltip support.

* **Improvements**
  * Error messages now direct users to the GitHub issues page for support and bug reporting.

* **Documentation**
  * Updated documentation with guidance on interactive chat prefix functionality and GitHub issue link targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->