### PR TITLE
🎨 Palette: Add explicit hover tooltips to display subcommand help texts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+## 2024-05-24 - Explicit Tooltips in Interactive Chat Feedback
+
+**Learning:** Vague tooltips like "Click to fill command" do not provide sufficient context when using `CommandUtils.buildInteractiveFeedback` for complex configuration submenus (e.g., `/levelhead display offset <value>`).
+**Action:** When constructing `/levelhead display` subcommand help texts, actively populate the `hoverTextOverride` parameter inside `CommandUtils.buildInteractiveFeedback` with specific actions (e.g., "Click to fill display header command") to increase intuitive interface interaction.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -1096,21 +1096,24 @@ private fun sendDisplayUsage() {
         command = "/levelhead display header <text|color>",
         suggestedCommand = "/levelhead display header ",
         run = false,
-        suffix = "${ChatColor.GRAY}, "
+        suffix = "${ChatColor.GRAY}, ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill display header command"
     )
     msg.appendSibling(CommandUtils.buildInteractiveFeedback(
         messagePrefix = "",
         command = "/levelhead display offset <value>",
         suggestedCommand = "/levelhead display offset ",
         run = false,
-        suffix = "${ChatColor.GRAY}, "
+        suffix = "${ChatColor.GRAY}, ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill display offset command"
     ))
     msg.appendSibling(CommandUtils.buildInteractiveFeedback(
         messagePrefix = "",
         command = "/levelhead display showself <on|off>",
         suggestedCommand = "/levelhead display showself ",
         run = false,
-        suffix = "${ChatColor.GRAY} to make changes."
+        suffix = "${ChatColor.GRAY} to make changes.",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill display showself command"
     ))
         sendMessage(msg)
     }
@@ -1121,7 +1124,8 @@ private fun sendDisplayHeaderDetails() {
         command = "/levelhead display header text <value>",
         suggestedCommand = "/levelhead display header text ",
         run = false,
-        suffix = "${ChatColor.YELLOW} to change it."
+        suffix = "${ChatColor.YELLOW} to change it.",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill header text command"
     )
         sendMessage(msg)
         sendDisplayHeaderColorHelp()
@@ -1133,7 +1137,8 @@ private fun sendDisplayHeaderColorHelp() {
         command = DISPLAY_HEADER_COLOR_COMMAND,
         suggestedCommand = DISPLAY_HEADER_COLOR_SUGGESTION,
         run = false,
-        suffix = "${ChatColor.YELLOW} with a hex code, RGB value, or "
+        suffix = "${ChatColor.YELLOW} with a hex code, RGB value, or ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill header color command"
     )
             .appendSibling(getMinecraftColorNameHelpComponent())
             .appendSibling(ChatComponentText("${ChatColor.YELLOW}."))
@@ -1147,7 +1152,8 @@ private fun sendDisplayOffsetDetails() {
         command = "/levelhead display offset <value>",
         suggestedCommand = "/levelhead display offset ",
         run = false,
-        suffix = "${ChatColor.YELLOW} with a value between "
+        suffix = "${ChatColor.YELLOW} with a value between ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill display offset command"
     )
             .appendSibling(ChatComponentText(String.format(Locale.ROOT, "%.1f", MIN_DISPLAY_OFFSET)).apply { chatStyle.color = ChatColor.GOLD })
             .appendSibling(ChatComponentText("${ChatColor.YELLOW} and "))


### PR DESCRIPTION
💡 What: Added explicit, context-specific hover tooltips (`hoverTextOverride`) to the interactive chat suggestions for `/levelhead display` subcommands (header text, header color, offset, and showself).

🎯 Why: The default tooltip ("Click to fill command") lacks context and is repetitive in a list of similar commands. Explicit tooltips let users know exactly which setting they are interacting with before they click, reducing accidental misclicks and improving overall intuitiveness in the configuration UI.

📸 Before/After:
Before: Hovering over the suggestion for `/levelhead display offset <value>` showed "Click to fill command".
After: It now explicitly shows "Click to fill display offset command".

♿ Accessibility: The clearer, descriptive labels improve semantic clarity for users relying on screen readers or navigating interactive chat densely populated with commands.

---
*PR created automatically by Jules for task [8946683670200887077](https://jules.google.com/task/8946683670200887077) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to interactive guidance elements in command help text, providing explicit descriptions of actions for better user clarity and guidance when using display customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->