### PR TITLE
🧱 Mason: Refactor toCSV utility using Generic Types

### DIFF
--- a/.jules/mason.md
+++ b/.jules/mason.md
@@ -46,3 +46,9 @@
 **Tech Debt:** Type `any`/`unknown` casting like `submission as unknown as import('./hypixel').HypixelPlayerResponse` was used for type coercion in `SubmissionService`.
 **Learning:** Chaining type casts via `unknown` completely disables compiler type checks and allows arbitrarily structured user input to bypass strict TS protections, risking runtime errors.
 **Prevention:** Rather than inline casting, introduce a strict structural type guard checking primitive and deep object fields (`isNonArrayObject(value) && typeof value.success === 'boolean'`) to properly narrow the type before property access.
+
+## 2026-05-08 - Refactor toCSV utility using Generic Types
+
+**Tech Debt:** The `toCSV` utility strictly demanded `Record<string, unknown>[]`, compelling its callers in `stats.ts` to repetitively use `as unknown as Record<string, unknown>[]` on typed domain objects before passing them in.
+**Learning:** Hardcoding a generic utility like CSV stringification to expect `Record<string, unknown>[]` breaks strict type inference at the call site, forcing the caller to disable TS constraints using `as unknown as Type`, which introduces runtime vulnerability risks.
+**Prevention:** In TypeScript utilities that process arrays of objects (such as `toCSV`), use generic type parameters (e.g., `<T extends object>(data: T[])`). This allows TypeScript to automatically infer the types of domain objects from callers. Internally, you can cast individual elements (e.g., `data[i] as Record<string, unknown>`) to safely access their keys without bleeding untyped assertions to the API's edges.

--- a/backend/src/routes/stats.ts
+++ b/backend/src/routes/stats.ts
@@ -193,7 +193,7 @@ router.get('/csv', async (req, res) => {
       endDate: validEndDate,
       });
 
-      const csv = toCSV(data as unknown as Record<string, unknown>[]);
+      const csv = toCSV(data);
 
       res.setHeader('Content-Type', 'text/csv');
       res.setHeader('Content-Disposition', 'attachment; filename="memory_stats.csv"');
@@ -216,7 +216,7 @@ router.get('/csv', async (req, res) => {
     });
     const data = (Array.isArray(rawData) ? rawData : []).map((entry) =>
       normalizePlayerQuerySummaryEntry(entry),
-    ) as unknown as Record<string, unknown>[];
+    );
 
     const csv = toCSV(data);
 

--- a/backend/src/util/csv.ts
+++ b/backend/src/util/csv.ts
@@ -27,9 +27,9 @@ const escapeCell = (val: unknown): string => {
   return sanitized;
 };
 
-export function toCSV(data: Record<string, unknown>[]): string {
+export function toCSV<T extends object>(data: T[]): string {
   if (data.length === 0) return '';
-  const headers = Object.keys(data[0]);
+  const headers = Object.keys(data[0] as Record<string, unknown>);
 
   // ⚡ Bolt: Replaced .map().join('\n') and intermediate array allocations with direct string concatenation (+=) and a single loop to reduce GC pressure when generating large CSVs
   const numRows = data.length;
@@ -44,7 +44,7 @@ export function toCSV(data: Record<string, unknown>[]): string {
   }
 
   for (let r = 0; r < numRows; r++) {
-    const row = data[r];
+    const row = data[r] as Record<string, unknown>;
     if (numCols === 0) {
       result += '\n';
       continue;

--- a/backend/tests/util/csv.test.ts
+++ b/backend/tests/util/csv.test.ts
@@ -1,0 +1,9 @@
+import { toCSV } from '../../src/util/csv';
+
+describe('csv utils', () => {
+  it('should convert objects to CSV', () => {
+    const data = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
+    const csv = toCSV(data);
+    expect(csv).toBe('a,b\n1,2\n3,4');
+  });
+});


### PR DESCRIPTION
💡 What: Refactored the `toCSV` utility function to use generic type parameters instead of strictly typed arrays, eliminating unsafe type casts at call sites.
🎯 Why: The previous code was a liability as it strictly demanded `Record<string, unknown>[]`, compelling its callers in `stats.ts` to repetitively use `as unknown as Record<string, unknown>[]` on typed domain objects. This broke strict type inference.
🛠️ How: Changed the signature of `toCSV` to `export function toCSV<T extends object>(data: T[]): string`. Internally, safely cast array elements to `Record<string, unknown>` to access keys. Updated call sites in `stats.ts` to remove the `as unknown as` assertions.
✅ Verification: Ran `cd backend && pnpm install --no-frozen-lockfile && pnpm run build && npx jest`. All 91 relevant tests passed, and added explicit test coverage for the `toCSV` function to verify correct behavior.

---
*PR created automatically by Jules for task [14336181454186619681](https://jules.google.com/task/14336181454186619681) started by @beenycool*