### PR TITLE
🎨 Palette: [UX improvement] Explicit tooltips for interactive chat elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,4 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+## 2026-05-10 - Explicit Tooltips for Clickable Text\n**Learning:** Vague tooltips like "Click to edit text" or "Click to open link" lack context for users navigating interactive chat configurations.\n**Action:** Always provide explicitly descriptive tooltips detailing exactly what happens (e.g., "Click to fill text command", "Click to open: url") when creating clickable text elements in chat.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/CommandUtils.kt
@@ -37,7 +37,7 @@ object CommandUtils {
     fun createClickableUrl(url: String, text: String = url): IChatComponent {
         return ChatComponentText(text).apply {
             chatStyle.chatClickEvent = ClickEvent(ClickEvent.Action.OPEN_URL, url)
-            chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open link"))
+            chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to open: $url"))
         }
     }
 

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -137,9 +137,9 @@ class LevelheadCommand {
         }
 
         sendMessage(mainComponent)
-        val headerClickable = CommandUtils.createClickableCommand("${ChatColor.GOLD}$header", run = false, suggestedCommand = "/levelhead display header text \"$header\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to edit text")) }
+        val headerClickable = CommandUtils.createClickableCommand("${ChatColor.GOLD}$header", run = false, suggestedCommand = "/levelhead display header text \"$header\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to fill text command")) }
         val offsetText = String.format(Locale.ROOT, "%.2f", offset)
-        val offsetClickable = CommandUtils.createClickableCommand("${ChatColor.GOLD}$offsetText", run = false, suggestedCommand = "/levelhead display offset $offsetText").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to edit offset")) }
+        val offsetClickable = CommandUtils.createClickableCommand("${ChatColor.GOLD}$offsetText", run = false, suggestedCommand = "/levelhead display offset $offsetText").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to fill offset command")) }
         val toggleClickable = createShowSelfToggleComponent(showSelf)
 
         val msg1 = ChatComponentText("${ChatColor.YELLOW}Header: ")
@@ -1074,16 +1074,16 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
         val offset = Levelhead.displayManager.config.offset
 
         val msg1 = ChatComponentText("${ChatColor.YELLOW}Primary header: ")
-        msg1.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$headerText", run = false, suggestedCommand = "/levelhead display header text \"$headerText\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to edit text")) })
+        msg1.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$headerText", run = false, suggestedCommand = "/levelhead display header text \"$headerText\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to fill text command")) })
         msg1.appendSibling(ChatComponentText("${ChatColor.YELLOW} ("))
         val colorHex = formatColor(headerColor)
-        msg1.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$colorHex", run = false, suggestedCommand = "$DISPLAY_HEADER_COLOR_SUGGESTION\"$colorHex\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to edit color")) })
+        msg1.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$colorHex", run = false, suggestedCommand = "$DISPLAY_HEADER_COLOR_SUGGESTION\"$colorHex\"").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to fill color command")) })
         msg1.appendSibling(ChatComponentText("${ChatColor.YELLOW})."))
         sendMessage(msg1)
 
         val msg2 = ChatComponentText("${ChatColor.YELLOW}Display offset: ")
         val offsetText = String.format(Locale.ROOT, "%.2f", offset)
-        msg2.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$offsetText", run = false, suggestedCommand = "/levelhead display offset $offsetText").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to edit offset")) })
+        msg2.appendSibling(CommandUtils.createClickableCommand("${ChatColor.GOLD}$offsetText", run = false, suggestedCommand = "/levelhead display offset $offsetText").apply { chatStyle.chatHoverEvent = HoverEvent(HoverEvent.Action.SHOW_TEXT, ChatComponentText("${ChatColor.GREEN}Click to fill offset command")) })
         msg2.appendSibling(ChatComponentText("${ChatColor.YELLOW}, show self "))
         msg2.appendSibling(createShowSelfToggleComponent(showSelf))
         msg2.appendSibling(ChatComponentText("${ChatColor.YELLOW}."))
@@ -1096,21 +1096,24 @@ private fun sendDisplayUsage() {
         command = "/levelhead display header <text|color>",
         suggestedCommand = "/levelhead display header ",
         run = false,
-        suffix = "${ChatColor.GRAY}, "
+        suffix = "${ChatColor.GRAY}, ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill header command"
     )
     msg.appendSibling(CommandUtils.buildInteractiveFeedback(
         messagePrefix = "",
         command = "/levelhead display offset <value>",
         suggestedCommand = "/levelhead display offset ",
         run = false,
-        suffix = "${ChatColor.GRAY}, "
+        suffix = "${ChatColor.GRAY}, ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill offset command"
     ))
     msg.appendSibling(CommandUtils.buildInteractiveFeedback(
         messagePrefix = "",
         command = "/levelhead display showself <on|off>",
         suggestedCommand = "/levelhead display showself ",
         run = false,
-        suffix = "${ChatColor.GRAY} to make changes."
+        suffix = "${ChatColor.GRAY} to make changes.",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill showself command"
     ))
         sendMessage(msg)
     }
@@ -1121,7 +1124,8 @@ private fun sendDisplayHeaderDetails() {
         command = "/levelhead display header text <value>",
         suggestedCommand = "/levelhead display header text ",
         run = false,
-        suffix = "${ChatColor.YELLOW} to change it."
+        suffix = "${ChatColor.YELLOW} to change it.",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill header text command"
     )
         sendMessage(msg)
         sendDisplayHeaderColorHelp()
@@ -1133,7 +1137,8 @@ private fun sendDisplayHeaderColorHelp() {
         command = DISPLAY_HEADER_COLOR_COMMAND,
         suggestedCommand = DISPLAY_HEADER_COLOR_SUGGESTION,
         run = false,
-        suffix = "${ChatColor.YELLOW} with a hex code, RGB value, or "
+        suffix = "${ChatColor.YELLOW} with a hex code, RGB value, or ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill color command"
     )
             .appendSibling(getMinecraftColorNameHelpComponent())
             .appendSibling(ChatComponentText("${ChatColor.YELLOW}."))
@@ -1147,7 +1152,8 @@ private fun sendDisplayOffsetDetails() {
         command = "/levelhead display offset <value>",
         suggestedCommand = "/levelhead display offset ",
         run = false,
-        suffix = "${ChatColor.YELLOW} with a value between "
+        suffix = "${ChatColor.YELLOW} with a value between ",
+        hoverTextOverride = "${ChatColor.GREEN}Click to fill offset command"
     )
             .appendSibling(ChatComponentText(String.format(Locale.ROOT, "%.1f", MIN_DISPLAY_OFFSET)).apply { chatStyle.color = ChatColor.GOLD })
             .appendSibling(ChatComponentText("${ChatColor.YELLOW} and "))


### PR DESCRIPTION
💡 What: Updated hover text tooltips for various clickable chat elements (like editing headers, offsets, and opening URLs) to explicitly describe the resulting action.
🎯 Why: Vague tooltips like "Click to edit text" were confusing as they did not make it clear that the action only fills the command in the chat box. Explicit tooltips improve clarity and set proper user expectations.
📸 Before/After: Tooltips changed from generic "Click to open link" and "Click to edit text" to "Click to open: [URL]" and "Click to fill text command".
♿ Accessibility: Improves clarity for all users navigating the mod's interactive chat configuration menus.

---
*PR created automatically by Jules for task [1356082107426032922](https://jules.google.com/task/1356082107426032922) started by @beenycool*