### PR TITLE
🎨 Palette: Make GitHub issue links clickable and point to /issues

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-05-24 - Clickable Mod Title for GUI Discovery
 **Learning:** Users often run the base command (`/levelhead`) to see what the mod does, but might miss the `/levelhead gui` subcommand in the long list of text options.
 **Action:** Make the primary mod title text in the status header clickable (with an explicit `HoverEvent` tooltip) to execute the GUI command, providing an intuitive, discoverable shortcut to the main settings interface.
+
+## 2024-05-25 - Standardize Clickable Issue Links
+**Learning:** In Minecraft chat interfaces, users often struggle to manually copy and paste long plain-text URLs, especially bug report links in error messages or welcome messages. Pointing them to the repository root instead of the direct `/issues` page adds unnecessary friction for bug reporting.
+**Action:** When providing GitHub repository links in error messages or interactive chat components, use `CommandUtils.createClickableUrl` to wrap the URLs in `ClickEvent.Action.OPEN_URL` so users can click them directly. Point the URLs directly to the `/issues` page to save an extra navigation step.

--- a/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/Levelhead.kt
@@ -222,9 +222,17 @@ return normalized.contains("hypixel")
         }
         LevelheadConfig.markWelcomeMessageShown()
         sendChat("${ChatColor.GREEN}Thanks for installing Levelhead!")
-        sendChat(
-            "${ChatColor.YELLOW}The mod is in alpha, so bugs may occur. ${ChatColor.GOLD}Report issues on GitHub or message ${ChatColor.AQUA}beenyiscool${ChatColor.GOLD} on Discord to request new features."
-        )
+
+        val welcomeMsg = net.minecraft.util.ChatComponentText("${ChatColor.YELLOW}The mod is in alpha, so bugs may occur. ${ChatColor.GOLD}Report issues on ")
+        welcomeMsg.appendSibling(club.sk1er.mods.levelhead.commands.CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub"))
+        welcomeMsg.appendSibling(net.minecraft.util.ChatComponentText("${ChatColor.GOLD} or message ${ChatColor.AQUA}beenyiscool${ChatColor.GOLD} on Discord to request new features."))
+
+        val formatted = net.minecraft.util.ChatComponentText("${ChatColor.AQUA}[Levelhead] ${ChatColor.RESET}")
+        formatted.appendSibling(welcomeMsg)
+
+        minecraft.addScheduledTask {
+            minecraft.thePlayer?.addChatMessage(formatted)
+        }
     }
 
     fun preInit(@Suppress("UNUSED_PARAMETER") event: FMLPreInitializationEvent) {

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/LevelheadCommand.kt
@@ -544,7 +544,7 @@ class LevelheadCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
             }
         }
     }
@@ -937,7 +937,7 @@ hoverTextOverride = "${ChatColor.GREEN}Click to fill import command"
                         run = true,
                         suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                     )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                     sendMessage(errorMsg)
                 }
             }

--- a/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
+++ b/src/main/kotlin/club/sk1er/mods/levelhead/commands/WhoisCommand.kt
@@ -53,7 +53,7 @@ class WhoisCommand {
                     run = true,
                     suffix = "${ChatColor.RED} to check your connection or check logs for details. If this issue persists, please make an issue on GitHub: "
                 )
-                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/", "${ChatColor.AQUA}GitHub."))
+                errorMsg.appendSibling(CommandUtils.createClickableUrl("https://github.com/beenycool/bedwars-level-head/issues", "${ChatColor.AQUA}GitHub."))
                 sendMessage(errorMsg)
             }
         }

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew test --no-daemon


### PR DESCRIPTION
💡 What: Updated the `showWelcomeMessageIfNeeded` in `Levelhead.kt` to use a clickable link for "GitHub" instead of plain text. Also updated all GitHub repository links in `LevelheadCommand.kt` and `WhoisCommand.kt` to point directly to the `/issues` page instead of the repository root.

🎯 Why: In Minecraft chat, long plain-text URLs are difficult to copy and paste manually. Wrapping them in a clickable chat component improves the user experience. Directing users to the `/issues` page saves them an extra navigation step when they encounter an error or want to report a bug.

📸 Before/After: Before, error logs had clickable links to the root repository, and the welcome message had unclickable plain text "GitHub" text. Now, the welcome message has a clickable "GitHub" component, and all error commands have a clickable link pointing directly to the `/issues` page.

♿ Accessibility: Ensures that links in the chat output are immediately actionable (`ClickEvent.Action.OPEN_URL`) rather than requiring manual text selection, and reduces cognitive load by taking the user directly to the action page.

---
*PR created automatically by Jules for task [1701360246430153136](https://jules.google.com/task/1701360246430153136) started by @beenycool*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub issue links in help messages and error feedback are now interactive and clickable, directing users to the issues page.

* **Documentation**
  * Updated documentation on formatting interactive links in chat components.

* **Tests**
  * Added test suite execution script.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beenycool/bedwars-level-head/pull/439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->